### PR TITLE
Expose Vite dev server to network

### DIFF
--- a/__tests__/vite-config.test.ts
+++ b/__tests__/vite-config.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2024 Blog Writer
+ *
+ * @fileoverview Tests Vite configuration for correct server exposure.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import config from '../vite.config';
+
+describe('Vite configuration', () => {
+  it('should expose server to all network interfaces', () => {
+    // host true or '0.0.0.0'
+    expect(config?.server?.host).toBe('0.0.0.0');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/main/index.js",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build:renderer": "vite build",
     "build": "electron-builder",
     "test": "vitest run --coverage",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2024 Blog Writer
+ *
+ * @fileoverview Vite configuration exposing dev server to all interfaces.
+ */
+
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- expose Vite dev server on all interfaces
- test Vite configuration for server exposure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689fb66708cc8332963653940f97b37f