### PR TITLE
Add project documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+<!-- Copyright 2024 Blog Writer -->
+# Documentation
+
+This directory houses documentation for Blog Writer. The following guides are available:
+
+- [User Guide](user-guide.md) – using the application.
+- [Developer Guide](developer-guide.md) – architecture and contribution guidelines.
+- [Build and Test Guide](build-and-test.md) – building, packaging, and testing.
+
+Each document complements the specification in `SPECIFICATION.md` and is maintained to reflect the current state of the project.

--- a/docs/build-and-test.md
+++ b/docs/build-and-test.md
@@ -1,0 +1,56 @@
+<!-- Copyright 2024 Blog Writer -->
+# Build and Test Guide
+
+This document describes how to build, package, and test Blog Writer.
+
+## Prerequisites
+
+- Go 1.24
+- Node.js 20
+- Wails CLI (`go install github.com/wailsapp/wails/v2/cmd/wails@latest`)
+- A working Git installation
+
+## Development Build
+
+```bash
+# install frontend dependencies
+cd blog-writer/frontend
+npm ci
+
+# run the development environment
+cd ..
+wails dev
+```
+
+`wails dev` starts a Vite development server with hot reload. A second dev server runs on `http://localhost:34115` for browser testing.
+
+## Production Build
+
+```bash
+# install frontend dependencies once
+cd blog-writer/frontend
+npm ci
+cd ..
+
+# build for the host platform
+wails build
+```
+
+To build for a specific platform, set `GOOS` and `GOARCH` and enable CGO:
+
+```bash
+CGO_ENABLED=1 GOOS=linux GOARCH=amd64 wails build -clean -platform linux/amd64
+```
+
+The GitHub Actions workflow builds binaries for Windows, Linux, and macOS on both `amd64` and `arm64` architectures and uploads artifacts for releases.
+
+## Testing
+
+Run Go tests from the project root:
+
+```bash
+cd blog-writer
+go test ./...
+```
+
+The frontend does not yet define a test script. Placeholder tests should be added as features are implemented.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,58 @@
+<!-- Copyright 2024 Blog Writer -->
+# Developer Guide
+
+This guide outlines the internal architecture of Blog Writer and conventions for contributing code.
+
+## Architecture Overview
+
+Blog Writer uses [Wails](https://wails.io) to combine a Go backend with a React + TypeScript frontend.
+
+### Backend (Go)
+
+Services are bound to the frontend via `wails.Run`:
+
+- `RepoService` – open or create repositories and manage recent repos and settings.
+- `GitService` – thin wrapper around the Git CLI for status, staging, commits, pulls (rebase), pushes, and branch operations.
+- `ArticleService` – CRUD operations, ID allocation, validation, and autosave logic.
+- `ImageService` – image conversion to sanitized SVG and Base64 encoding.
+- `SchemaService` – validates article JSON against the schema and handles migrations.
+
+### Frontend (React + TypeScript)
+
+The frontend is a single‑page application served by Wails’ WebView. It provides:
+
+- A WYSIWYG editor, metadata form, JSON preview, Git panel, and diagnostics area.
+- LaTeX preview using a renderer such as KaTeX. TeX source is stored in `math` nodes.
+- Calls to Go services via generated Wails bindings (e.g., `window.go.services.ArticleService.Save`).
+
+### Security
+
+The application uses only local assets. The Content‑Security‑Policy blocks remote code, and the SVG sanitizer removes scripts, external references, and nodes over configured limits.
+
+## Repository Structure
+
+```
+repo-root/
+  blog/                # article JSON files
+  .blog-writer/        # settings
+  blog-writer/         # application source
+    frontend/          # React + TypeScript UI
+    app.go             # Wails application setup
+    main.go            # entry point
+```
+
+Article files are named with their Unix epoch second. Settings are stored in `.blog-writer/settings.json`.
+
+## Coding Conventions
+
+- **Modularity:** Organize code into focused packages and components.
+- **Test‑Driven Development:** Write unit tests before implementing features.
+- **Documentation:** Provide doc strings for all exported functions and types.
+- **Copyright:** Each source file begins with the appropriate copyright comment.
+
+## Extending the Program
+
+1. Create or update Go services in the backend for new functionality.
+2. Expose methods through Wails bindings and use them in the React frontend.
+3. Maintain schema compatibility when altering the article format; include migration hooks if needed.
+4. Validate new features with automated tests and update documentation accordingly.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,35 @@
+<!-- Copyright 2024 Blog Writer -->
+# User Guide
+
+Blog Writer is an offline desktop editor for authoring blog articles as JSON files inside a Git repository.
+
+## Getting Started
+
+1. **Launch Blog Writer.** On first run a wizard appears with three choices:
+   - **Open existing repo** – choose a folder containing a `.git` directory.
+   - **Open recent repo** – select from your most recently opened repositories.
+   - **Create local repo from remote** – provide a GitHub SSH URL and a local path. The app runs `git init`, adds the remote, optionally fetches, creates `blog/` and `.blog-writer/`, makes an initial commit, and can push to the remote.
+
+2. **Repository layout**
+   - Articles live under `blog/` and are named by the Unix epoch second of creation, e.g. `blog/1755288225.json`.
+   - Settings are stored in `.blog-writer/settings.json`.
+
+## Editing Articles
+
+- The editor supports headings, paragraphs, inline formatting (`b`, `i`, `u`, `strong`, `em`, `code`, `sub`, `sup`, `s`, `mark`, `small`), line breaks, lists, quotes, horizontal rules, code blocks, tables, semantic containers, math, and embedded SVG images.
+- Images are vectorized when needed, sanitized, and stored as Base64‑encoded data URIs.
+- Math is entered as TeX and previewed in the app.
+
+## Saving and Version Control
+
+- **Autosave** writes changes to disk every 15 seconds and on blur without committing.
+- **Save** writes the file and creates a Git commit with the message `chore(article): <id> <title> [create|update|delete]`.
+- All Git operations are performed using the Git CLI; status, stage, commit, pull (rebase), push, and branch operations are available through the interface.
+
+## Validating Content
+
+Articles are validated against the project's JSON schema before committing. Invalid content blocks the commit and surfaces actionable diagnostics in the UI.
+
+## Working Offline
+
+Blog Writer is fully offline. All assets are local, and the Content‑Security‑Policy forbids remote code execution.


### PR DESCRIPTION
## Summary
- add docs directory with user, developer, and build/test guides

## Testing
- `go test ./...` *(fails: main.go:11:12: pattern all:frontend/dist: no matching files found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689fcb221b408332b07db1508be1082b