### PR TITLE
Add versioning CLI tool with tests

### DIFF
--- a/tools/tests/test_versioning.py
+++ b/tools/tests/test_versioning.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 Sam Caldwell
+# SPDX-License-Identifier: MIT
+"""Tests for the versioning CLI tool."""
+
+
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "tools" / "versioning"
+
+
+def run_tool(tmp_path, args):
+    """Run the versioning tool with the given arguments inside tmp_path."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_help_message(tmp_path):
+    """The tool should display usage information when no arguments are given."""
+    result = run_tool(tmp_path, [])
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()
+
+
+def test_major_creates_file(tmp_path):
+    """Invoking with 'major' should create VERSION with v1.0.0 when absent."""
+    result = run_tool(tmp_path, ["major"])
+    assert result.returncode == 0
+    assert (tmp_path / "VERSION").read_text().strip() == "v1.0.0"
+
+
+def test_minor_bump(tmp_path):
+    """Invoking with 'minor' should increment the minor version and reset release."""
+    version_file = tmp_path / "VERSION"
+    version_file.write_text("v1.2.3")
+    result = run_tool(tmp_path, ["minor"])
+    assert result.returncode == 0
+    assert version_file.read_text().strip() == "v1.3.0"
+
+
+def test_release_bump(tmp_path):
+    """Invoking with 'release' should increment the release version."""
+    version_file = tmp_path / "VERSION"
+    version_file.write_text("v1.2.3")
+    result = run_tool(tmp_path, ["release"])
+    assert result.returncode == 0
+    assert version_file.read_text().strip() == "v1.2.4"

--- a/tools/versioning
+++ b/tools/versioning
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""CLI entry point for repository version management."""
+
+# Copyright (c) 2025 Sam Caldwell
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from versioning_lib import ensure_version_file, run
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create and return the argument parser for the CLI."""
+    parser = argparse.ArgumentParser(description="Bump the repository version.")
+    parser.add_argument(
+        "level",
+        nargs="?",
+        choices=["major", "minor", "release"],
+        help="Version part to bump",
+    )
+    return parser
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    parser = build_parser()
+    args = parser.parse_args()
+    version_file = Path.cwd() / "VERSION"
+    ensure_version_file(version_file)
+
+    if not args.level:
+        parser.print_help()
+        return
+
+    new_version = run(args.level, version_file)
+    print(f"v{new_version[0]}.{new_version[1]}.{new_version[2]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/versioning_lib.py
+++ b/tools/versioning_lib.py
@@ -1,0 +1,73 @@
+"""Library functions for the versioning CLI tool."""
+
+# Copyright (c) 2025 Sam Caldwell
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+VersionTuple = Tuple[int, int, int]
+
+def ensure_version_file(path: Path) -> None:
+    """Ensure the VERSION file exists, creating it with v0.0.0 if missing."""
+    if not path.exists():
+        path.write_text("v0.0.0\n")
+
+def read_version(path: Path) -> VersionTuple:
+    """Read the current version from *path*.
+
+    Parameters
+    ----------
+    path: Path
+        Path to the VERSION file.
+
+    Returns
+    -------
+    VersionTuple
+        A tuple of (major, minor, release).
+    """
+    ensure_version_file(path)
+    content = path.read_text().strip()
+    if not content.startswith("v"):
+        raise ValueError("Version must start with 'v'")
+    parts = content[1:].split(".")
+    if len(parts) != 3:
+        raise ValueError("Version must have three numeric parts")
+    return tuple(int(p) for p in parts)  # type: ignore[return-value]
+
+def write_version(path: Path, version: VersionTuple) -> None:
+    """Write *version* to *path* in vM.m.r format."""
+    path.write_text(f"v{version[0]}.{version[1]}.{version[2]}\n")
+
+def bump_version(level: str, version: VersionTuple) -> VersionTuple:
+    """Return a new version tuple bumped at *level*.
+
+    Parameters
+    ----------
+    level: str
+        One of 'major', 'minor', or 'release'.
+    version: VersionTuple
+        The current version.
+    """
+    major, minor, release = version
+    if level == "major":
+        major += 1
+        minor = 0
+        release = 0
+    elif level == "minor":
+        minor += 1
+        release = 0
+    elif level == "release":
+        release += 1
+    else:
+        raise ValueError("level must be 'major', 'minor', or 'release'")
+    return major, minor, release
+
+def run(level: str, path: Path) -> VersionTuple:
+    """Read, bump, and write the version at *path* according to *level*."""
+    current = read_version(path)
+    new_version = bump_version(level, current)
+    write_version(path, new_version)
+    return new_version


### PR DESCRIPTION
## Summary
- add `versioning` CLI for semantic version bumps stored in VERSION file
- implement supporting library with version parsing and bump logic
- test major/minor/release bumps and help output

## Testing
- `pytest tools/tests/test_versioning.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689fcc5e7d60833298c23cc61aaeda51