### PR TITLE
Add Help/About menu dialog

### DIFF
--- a/blog-writer/app.go
+++ b/blog-writer/app.go
@@ -1,27 +1,41 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
 package main
 
 import (
 	"context"
 	"fmt"
+
+	"github.com/wailsapp/wails/v2/pkg/menu"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+
+	"blog-writer/internal/about"
 )
 
-// App struct
+// App holds application state.
 type App struct {
 	ctx context.Context
 }
 
-// NewApp creates a new App application struct
+// NewApp creates a new App application struct.
 func NewApp() *App {
 	return &App{}
 }
 
 // startup is called when the app starts. The context is saved
-// so we can call the runtime methods
+// so we can call the runtime methods.
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 }
 
-// Greet returns a greeting for the given name
+// Greet returns a greeting for the given name.
 func (a *App) Greet(name string) string {
 	return fmt.Sprintf("Hello %s, It's show time!", name)
+}
+
+// ShowAbout displays the application's about information.
+func (a *App) ShowAbout(data *menu.CallbackData) {
+	runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
+		Title:   "About",
+		Message: about.Info(),
+	})
 }

--- a/blog-writer/internal/about/about.go
+++ b/blog-writer/internal/about/about.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+package about
+
+// Info returns the about dialog message.
+func Info() string {
+	return `Blog Writer
+
+MIT License
+
+(c) 2025 Asymmetric Effort, LLC.  <scaldwell@asymmetric-effort.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.`
+}

--- a/blog-writer/internal/about/about_test.go
+++ b/blog-writer/internal/about/about_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+package about
+
+import "testing"
+
+// TestInfo verifies that Info returns the correct about message.
+func TestInfo(t *testing.T) {
+	expected := `Blog Writer
+
+MIT License
+
+(c) 2025 Asymmetric Effort, LLC.  <scaldwell@asymmetric-effort.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.`
+
+	if Info() != expected {
+		t.Errorf("expected about info to match\n%s\n got\n%s", expected, Info())
+	}
+}

--- a/blog-writer/main.go
+++ b/blog-writer/main.go
@@ -1,9 +1,11 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
 package main
 
 import (
 	"embed"
 
 	"github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 )
@@ -12,10 +14,15 @@ import (
 var assets embed.FS
 
 func main() {
-	// Create an instance of the app structure
+	// Create an instance of the app structure.
 	app := NewApp()
 
-	// Create application with options
+	// Create application menu.
+	appMenu := menu.NewMenu()
+	helpMenu := appMenu.AddSubmenu("Help")
+	helpMenu.AddText("About", nil, app.ShowAbout)
+
+	// Create application with options.
 	err := wails.Run(&options.App{
 		Title:  "blog-writer",
 		Width:  1024,
@@ -23,6 +30,7 @@ func main() {
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
+		Menu:             appMenu,
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
 		OnStartup:        app.startup,
 		Bind: []interface{}{


### PR DESCRIPTION
## Summary
- add about info package and tests
- show license details in Help > About dialog
- wire up Help menu in main window

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689fd57e48ec8332be817a371a9eda52