### PR TITLE
feat: show repo wizard in modal

### DIFF
--- a/blog-writer/frontend/src/App.tsx
+++ b/blog-writer/frontend/src/App.tsx
@@ -1,23 +1,24 @@
 // Copyright (c) 2025 Sam Caldwell
 // SPDX-License-Identifier: MIT
 
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import Editor from './components/Editor';
 import RepoWizard from './pages/RepoWizard';
+import Modal from './components/Modal';
 
 /**
- * App renders the WYSIWYG editor once a repository is opened or created.
+ * App renders the WYSIWYG editor with a modal repo wizard.
  */
-function App(): JSX.Element {
+export default function App(): JSX.Element {
+  const [showRepoWizard] = useState(true);
+
   return (
     <div id="App">
-      <div>
-        <Editor />
-      </div>
-      <div>
-        <RepoWizard/>
-      </div>
+      <Editor />
+      <Modal open={showRepoWizard}>
+        <RepoWizard />
+      </Modal>
     </div>
   );
-export default App;
+}

--- a/blog-writer/frontend/src/__tests__/App.test.tsx
+++ b/blog-writer/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+/// <reference types="vitest" />
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+vi.mock('../../wailsjs/go/services/RepoService', () => ({
+  Recent: () => Promise.resolve([]),
+  Open: vi.fn(),
+  Create: vi.fn()
+}));
+import App from '../App';
+
+/**
+ * Render tests for the App component ensuring the RepoWizard appears as a modal.
+ */
+describe('App', () => {
+  it('renders RepoWizard inside a modal dialog', () => {
+    render(<App />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Blog Repo Wizard')).toBeInTheDocument();
+  });
+});

--- a/blog-writer/frontend/src/components/Modal.tsx
+++ b/blog-writer/frontend/src/components/Modal.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+
+/**
+ * Modal wraps content in a dialog element displayed above the main window.
+ */
+interface ModalProps {
+  /** True if the modal should be displayed. */
+  open: boolean;
+  /** Content to display within the modal. */
+  children: React.ReactNode;
+}
+
+export default function Modal({ open, children }: ModalProps): JSX.Element | null {
+  if (!open) return null;
+  return (
+    <dialog open>
+      {children}
+    </dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- render RepoWizard inside a reusable Modal component that overlays the main editor
- add Modal component for dialog rendering
- add tests verifying the RepoWizard modal appears

## Testing
- `cd blog-writer/frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_689fd75711cc8332a5a3b806924f98a6