### PR TITLE
feat: add tabbed repo wizard

### DIFF
--- a/blog-writer/frontend/src/__tests__/App.test.tsx
+++ b/blog-writer/frontend/src/__tests__/App.test.tsx
@@ -26,7 +26,7 @@ describe('App', () => {
     vi.useFakeTimers();
     render(<App />);
     vi.advanceTimersByTime(15000);
-    expect(await screen.findByText('Blog Repo Wizard')).toBeInTheDocument();
+    expect(await screen.findByText('Open')).toBeInTheDocument();
     vi.useRealTimers();
   });
 });

--- a/blog-writer/frontend/src/components/Modal.tsx
+++ b/blog-writer/frontend/src/components/Modal.tsx
@@ -16,7 +16,7 @@ interface ModalProps {
 export default function Modal({ open, children }: ModalProps): JSX.Element | null {
   if (!open) return null;
   return (
-    <dialog open>
+    <dialog open style={{ borderRadius: '5px' }}>
       {children}
     </dialog>
   );

--- a/blog-writer/frontend/src/components/__tests__/Modal.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 blog-writer authors
+// SPDX-License-Identifier: MIT
+/// <reference types="vitest" />
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import Modal from '../Modal';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Modal style tests.
+ */
+describe('Modal', () => {
+  it('applies 5px border radius', () => {
+    render(
+      <Modal open>
+        <div>content</div>
+      </Modal>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveStyle({ borderRadius: '5px' });
+  });
+});

--- a/blog-writer/frontend/src/pages/RepoWizard.css
+++ b/blog-writer/frontend/src/pages/RepoWizard.css
@@ -1,0 +1,25 @@
+/* Copyright (c) 2025 blog-writer authors */
+.tabs {
+  display: flex;
+}
+.tabs button {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  cursor: pointer;
+}
+.tabs .inactive {
+  background-color: #ccc;
+}
+.tabs .active {
+  background-color: #eee;
+}
+.open-tab table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.open-tab th,
+.open-tab td {
+  border: 1px solid #888;
+  padding: 0.25rem;
+}

--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -1,69 +1,116 @@
 // Copyright (c) 2024 blog-writer authors
-import {useEffect, useState} from 'react';
-import {Create, Open, Recent} from '../../wailsjs/go/services/RepoService';
+import { useEffect, useState } from 'react';
+import { Create, Open, Recent, type RecentRepo } from '../../wailsjs/go/services/RepoService';
 import PathPicker from '../components/PathPicker';
+import './RepoWizard.css';
 
 /**
  * RepoWizard presents options to open or create repositories and choose from recent ones.
  */
 interface RepoWizardProps {
-    /** Callback when a repository has been opened. */
-    onOpen: (path: string) => void;
+  /** Callback when a repository has been opened. */
+  onOpen: (path: string) => void;
 }
 
 export default function RepoWizard({ onOpen }: RepoWizardProps) {
-    const [existingPath, setExistingPath] = useState('');
-    const [newPath, setNewPath] = useState('');
-    const [remote, setRemote] = useState('');
-    const [recent, setRecent] = useState<string[]>([]);
+  const [tab, setTab] = useState<'open' | 'create'>('open');
+  const [recent, setRecent] = useState<RecentRepo[]>([]);
+  const [parentDir, setParentDir] = useState('');
+  const [repoName, setRepoName] = useState('');
+  const [remote, setRemote] = useState('');
 
-    useEffect(() => {
-        Recent().then(setRecent);
-    }, []);
+  useEffect(() => {
+    Recent().then(setRecent);
+  }, []);
 
-    const openExisting = async () => {
-        if (existingPath) {
-            await Open(existingPath);
-            onOpen(existingPath);
+  const handleExisting = async (p: string) => {
+    try {
+      await Open(p);
+      onOpen(p);
+    } catch (err) {
+      if (String(err).includes('not a git repository')) {
+        if (window.confirm('Initialize directory as blog content repository?')) {
+          await Create('', p);
+          onOpen(p);
         }
-    };
+      } else {
+        window.alert('Failed to open repository');
+      }
+    }
+  };
 
-    const createNew = async () => {
-        if (newPath) {
-            await Create(remote, newPath);
-            setRecent(await Recent());
-            onOpen(newPath);
-        }
-    };
+  const handleCreate = async () => {
+    if (parentDir && repoName) {
+      const full = `${parentDir}/${repoName}`;
+      await Create(remote, full);
+      setRecent(await Recent());
+      onOpen(full);
+    }
+  };
 
-    const openRecent = async (p: string) => {
-        await Open(p);
-    };
+  const openRecent = async (p: string) => {
+    try {
+      await Open(p);
+      onOpen(p);
+    } catch {
+      window.alert('Failed to open repository');
+    }
+  };
 
-    return (
-        <div>
-            <h1>Blog Repo Wizard</h1>
-            <section>
-                <h2>Open Existing Repo</h2>
-                <PathPicker onChange={setExistingPath} />
-                <button onClick={openExisting}>Open</button>
-            </section>
-            <section>
-                <h2>Create Repo from Remote</h2>
-                <input placeholder="SSH URL" value={remote} onChange={e => setRemote(e.target.value)}/>
-                <PathPicker onChange={setNewPath} />
-                <button onClick={createNew}>Create</button>
-            </section>
-            <section>
-                <h2>Recent Repos</h2>
-                <select onChange={e => openRecent(e.target.value)} value="">
-                    <option value="" disabled>Select...</option>
-                    {recent.map(r => (
-                        <option key={r} value={r}>{r}</option>
-                    ))}
-                </select>
-            </section>
+  return (
+    <div className="repo-wizard">
+      <div className="tabs">
+        <button
+          className={tab === 'open' ? 'active' : 'inactive'}
+          onClick={() => setTab('open')}
+        >
+          Open
+        </button>
+        <button
+          className={tab === 'create' ? 'active' : 'inactive'}
+          onClick={() => setTab('create')}
+        >
+          Create
+        </button>
+      </div>
+      {tab === 'open' && (
+        <div className="open-tab">
+          <PathPicker onChange={handleExisting} />
+          <table>
+            <thead>
+              <tr>
+                <th>Path</th>
+                <th>Last Opened</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.map((r) => (
+                <tr key={r.path} onDoubleClick={() => openRecent(r.path)}>
+                  <td>{r.path}</td>
+                  <td>{new Date(r.lastOpened).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
-    );
+      )}
+      {tab === 'create' && (
+        <div className="create-tab">
+          <PathPicker onChange={setParentDir} />
+          <input
+            placeholder="Repository Name"
+            value={repoName}
+            onChange={(e) => setRepoName(e.target.value)}
+          />
+          <input
+            placeholder="SSH URL (optional)"
+            value={remote}
+            onChange={(e) => setRemote(e.target.value)}
+          />
+          <button onClick={handleCreate}>Create</button>
+        </div>
+      )}
+    </div>
+  );
 }
 

--- a/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
+++ b/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
@@ -5,8 +5,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 vi.mock('../../wailsjs/go/services/RepoService', () => ({
-  Recent: () => Promise.resolve(['r1']),
-  Open: vi.fn(),
+  Recent: () => Promise.resolve([{ path: 'r1', lastOpened: '2024-01-01T00:00:00Z' }]),
+  Open: vi.fn().mockResolvedValue(undefined),
   Create: vi.fn()
 }));
 import RepoWizard from '../RepoWizard';
@@ -15,11 +15,17 @@ import RepoWizard from '../RepoWizard';
  * RepoWizard interaction tests.
  */
 describe('RepoWizard', () => {
-  it('renders recent repos dropdown', async () => {
+  it('defaults to Open tab and opens repo on double click', async () => {
     const onOpen = vi.fn();
     render(<RepoWizard onOpen={onOpen} />);
-    await waitFor(() => screen.getByText('r1'));
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'r1' } });
-    expect(onOpen).toHaveBeenCalled();
+    const row = await screen.findByText('r1');
+    fireEvent.doubleClick(row);
+    await waitFor(() => expect(onOpen).toHaveBeenCalledWith('r1'));
+  });
+
+  it('switches to Create tab', () => {
+    render(<RepoWizard onOpen={vi.fn()} />);
+    fireEvent.click(screen.getByText('Create'));
+    expect(screen.getByPlaceholderText('Repository Name')).toBeInTheDocument();
   });
 });

--- a/blog-writer/frontend/wailsjs/go/services/RepoService.d.ts
+++ b/blog-writer/frontend/wailsjs/go/services/RepoService.d.ts
@@ -5,4 +5,9 @@ export function Create(arg1:string,arg2:string):Promise<void>;
 
 export function Open(arg1:string):Promise<void>;
 
-export function Recent():Promise<Array<string>>;
+export interface RecentRepo {
+  path: string;
+  lastOpened: string;
+}
+
+export function Recent():Promise<Array<RecentRepo>>;

--- a/blog-writer/internal/services/repo_test.go
+++ b/blog-writer/internal/services/repo_test.go
@@ -2,42 +2,50 @@
 package services
 
 import (
-	"os"
-	"path/filepath"
-	"strconv"
-	"testing"
+        "os"
+        "path/filepath"
+        "strconv"
+        "testing"
+        "time"
 )
 
-// TestRecent ensures recent repos list maintains order and limit.
+// TestRecent ensures recent repos list maintains order, limit, and timestamps.
 func TestRecent(t *testing.T) {
-	cfg := t.TempDir()
-	svc := NewRepoServiceWithDir(cfg)
+        cfg := t.TempDir()
+        svc := NewRepoServiceWithDir(cfg)
 
-	root := t.TempDir()
-	for i := 0; i < 6; i++ {
-		p := filepath.Join(root, "repo"+strconv.Itoa(i))
-		// simulate git repo
-		if err := os.MkdirAll(filepath.Join(p, ".git"), 0o755); err != nil {
-			t.Fatalf("mkdir: %v", err)
-		}
-		if err := svc.Open(p); err != nil {
-			t.Fatalf("open: %v", err)
-		}
-	}
-	rec, err := svc.Recent()
-	if err != nil {
-		t.Fatalf("recent: %v", err)
-	}
-	if len(rec) != 5 {
-		t.Fatalf("expected 5 recents, got %d", len(rec))
-	}
-	// reopen repo3
-	target := filepath.Join(root, "repo3")
-	if err := svc.Open(target); err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	rec, _ = svc.Recent()
-	if rec[0] != target {
-		t.Fatalf("expected %s at front, got %s", target, rec[0])
-	}
+        root := t.TempDir()
+        for i := 0; i < 6; i++ {
+                p := filepath.Join(root, "repo"+strconv.Itoa(i))
+                if err := os.MkdirAll(filepath.Join(p, ".git"), 0o755); err != nil {
+                        t.Fatalf("mkdir: %v", err)
+                }
+                if err := svc.Open(p); err != nil {
+                        t.Fatalf("open: %v", err)
+                }
+                time.Sleep(10 * time.Millisecond)
+        }
+        rec, err := svc.Recent()
+        if err != nil {
+                t.Fatalf("recent: %v", err)
+        }
+        if len(rec) != 5 {
+                t.Fatalf("expected 5 recents, got %d", len(rec))
+        }
+        for _, r := range rec {
+                if r.LastOpened.IsZero() {
+                        t.Fatalf("expected LastOpened to be set for %s", r.Path)
+                }
+        }
+        target := filepath.Join(root, "repo3")
+        if err := svc.Open(target); err != nil {
+                t.Fatalf("open: %v", err)
+        }
+        rec, _ = svc.Recent()
+        if rec[0].Path != target {
+                t.Fatalf("expected %s at front, got %s", target, rec[0].Path)
+        }
+        if !rec[0].LastOpened.After(rec[1].LastOpened) {
+                t.Fatalf("expected %s to have latest timestamp", target)
+        }
 }


### PR DESCRIPTION
## Summary
- add horizontal tabbed interface for repository wizard with open/create flows
- track last-opened repos with timestamps and expose to frontend
- style modal with 5px border radius and expand tests

## Testing
- `npm test` *(fails: @vitejs/plugin-react can't detect preamble)*
- `go test ./internal/services -run TestRecent -v`
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_b_689fe873ca58833287297511d5c6affa