### PR TITLE
feat: enhance repo wizard and layout

### DIFF
--- a/blog-writer/frontend/src/App.css
+++ b/blog-writer/frontend/src/App.css
@@ -1,3 +1,5 @@
+/* Copyright (c) 2025 blog-writer authors */
+/* SPDX-License-Identifier: MIT */
 #App.app-window {
     height: 100vh;
     display: flex;
@@ -11,6 +13,16 @@
 
 .editor-container {
     flex: 1;
+    display: flex;
+}
+
+.editor-container .ql-container {
+    flex: 1;
+    height: 100%;
+}
+
+.editor-container .ql-editor {
+    height: 100%;
 }
 
 #logo {

--- a/blog-writer/frontend/src/App.tsx
+++ b/blog-writer/frontend/src/App.tsx
@@ -35,12 +35,12 @@ export default function App(): JSX.Element {
     <div id="App" className="app-window">
       <MenuBar />
       <div className="main-area">
-        <FileTree repo={repo} onSelect={setFile} />
         <div className="editor-container">
           <Editor />
         </div>
+        <FileTree repo={repo} onSelect={setFile} />
       </div>
-      <StatusBar repo={repo} file={file} />
+      <StatusBar repo={repo} file={file} wizardOpen={showRepoWizard} />
       <Modal open={showRepoWizard}>
         {showLogo ? <img src={logo} alt="logo" /> : <RepoWizard onOpen={handleOpen} />}
       </Modal>

--- a/blog-writer/frontend/src/__tests__/App.test.tsx
+++ b/blog-writer/frontend/src/__tests__/App.test.tsx
@@ -1,32 +1,47 @@
 // Copyright (c) 2025 Sam Caldwell
 // SPDX-License-Identifier: MIT
 /// <reference types="vitest" />
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
-vi.mock('../../wailsjs/go/services/RepoService', () => ({
-  Recent: () => Promise.resolve([]),
-  Open: vi.fn(),
-  Create: vi.fn()
-}));
 import App from '../App';
 
 /**
  * Render tests for the App component ensuring the RepoWizard appears as a modal.
  */
 describe('App', () => {
+  beforeEach(() => {
+    const svc = (window as any).go.services.RepoService;
+    svc.Recent.mockResolvedValue([]);
+    svc.Open.mockResolvedValue(undefined);
+    svc.Create.mockResolvedValue(undefined);
+  });
+
   it('renders RepoWizard inside a modal dialog', () => {
     render(<App />);
     expect(screen.getByRole('dialog')).toBeInTheDocument();
-    // initial logo shown
     expect(screen.getByRole('img')).toBeInTheDocument();
   });
 
   it('shows RepoWizard after logo delay', async () => {
     vi.useFakeTimers();
     render(<App />);
-    vi.advanceTimersByTime(15000);
-    expect(await screen.findByText('Open')).toBeInTheDocument();
+    await act(async () => {
+      vi.runAllTimers();
+    });
+    expect(screen.getByText('Open')).toBeInTheDocument();
     vi.useRealTimers();
+  });
+
+  it('keeps navigation pane on right when no repository open', () => {
+    render(<App />);
+    const tree = document.querySelector('.main-area .file-tree');
+    expect(tree).not.toBeNull();
+    expect(tree?.previousElementSibling?.className).toContain('editor-container');
+  });
+
+  it('shows repo wizard status message', () => {
+    render(<App />);
+    expect(screen.getByText('Open or create a blog content repository.')).toBeInTheDocument();
   });
 });

--- a/blog-writer/frontend/src/components/Editor.tsx
+++ b/blog-writer/frontend/src/components/Editor.tsx
@@ -10,7 +10,7 @@ import 'react-quill/dist/quill.snow.css';
  */
 export const Editor: React.FC = () => {
   const [value, setValue] = useState<string>('');
-  return <ReactQuill theme="snow" value={value} onChange={setValue} />;
+  return <ReactQuill theme="snow" value={value} onChange={setValue} style={{ height: '100%' }} />;
 };
 
 export default Editor;

--- a/blog-writer/frontend/src/components/Modal.tsx
+++ b/blog-writer/frontend/src/components/Modal.tsx
@@ -16,8 +16,25 @@ interface ModalProps {
 export default function Modal({ open, children }: ModalProps): JSX.Element | null {
   if (!open) return null;
   return (
-    <dialog open style={{ borderRadius: '5px' }}>
-      {children}
-    </dialog>
+    <div
+      className="modal-overlay"
+      data-testid="modal-overlay"
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <dialog open style={{ borderRadius: '5px' }}>
+        {children}
+      </dialog>
+    </div>
   );
 }

--- a/blog-writer/frontend/src/components/StatusBar.tsx
+++ b/blog-writer/frontend/src/components/StatusBar.tsx
@@ -12,8 +12,15 @@ interface StatusBarProps {
   repo: string;
   /** Selected file name. */
   file: string;
+  /** True when the repository wizard is visible. */
+  wizardOpen: boolean;
 }
 
-export default function StatusBar({ repo, file }: StatusBarProps): JSX.Element {
-  return <div className="status-bar">{repo && `${repo} - ${file}`}</div>;
+export default function StatusBar({ repo, file, wizardOpen }: StatusBarProps): JSX.Element {
+  const text = wizardOpen
+    ? 'Open or create a blog content repository.'
+    : repo
+    ? `${repo} - ${file}`
+    : '';
+  return <div className="status-bar">{text}</div>;
 }

--- a/blog-writer/frontend/src/components/__tests__/Editor.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/Editor.test.tsx
@@ -15,4 +15,10 @@ describe('Editor', () => {
     const textbox = screen.getByRole('textbox');
     expect(textbox).toBeInTheDocument();
   });
+
+  it('stretches to full height', () => {
+    render(<Editor />);
+    const wrapper = document.querySelector('.ql-container')?.parentElement as HTMLElement;
+    expect(wrapper).toHaveStyle({ height: '100%' });
+  });
 });

--- a/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
@@ -2,22 +2,29 @@
 // SPDX-License-Identifier: MIT
 /// <reference types="vitest" />
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-vi.mock('../../wailsjs/go/services/TreeService', () => ({
-  List: () => Promise.resolve(['a.txt'])
-}));
 import FileTree from '../FileTree';
 
 /**
  * Tests for FileTree component ensure files load and selection works.
  */
 describe('FileTree', () => {
+  beforeEach(() => {
+    (window as any).go.services.TreeService.List.mockResolvedValue(['a.txt']);
+  });
+
   it('renders files from service', async () => {
     const onSelect = vi.fn();
     render(<FileTree repo="/repo" onSelect={onSelect} />);
     await waitFor(() => screen.getByText('a.txt'));
     fireEvent.click(screen.getByText('a.txt'));
     expect(onSelect).toHaveBeenCalledWith('a.txt');
+  });
+
+  it('renders even when no repository is open', () => {
+    const onSelect = vi.fn();
+    render(<FileTree repo="" onSelect={onSelect} />);
+    expect(screen.getByRole('list')).toBeInTheDocument();
   });
 });

--- a/blog-writer/frontend/src/components/__tests__/Modal.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/Modal.test.tsx
@@ -19,4 +19,15 @@ describe('Modal', () => {
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveStyle({ borderRadius: '5px' });
   });
+
+  it('renders translucent backdrop when open', () => {
+    render(
+      <Modal open>
+        <div>content</div>
+      </Modal>
+    );
+    const overlay = screen.getByTestId('modal-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveStyle({ backgroundColor: 'rgba(0, 0, 0, 0.5)' });
+  });
 });

--- a/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
@@ -11,7 +11,12 @@ import StatusBar from '../StatusBar';
  */
 describe('StatusBar', () => {
   it('shows repository and file info', () => {
-    render(<StatusBar repo="/repo" file="file.txt" />);
+    render(<StatusBar repo="/repo" file="file.txt" wizardOpen={false} />);
     expect(screen.getByText('/repo - file.txt')).toBeInTheDocument();
+  });
+
+  it('shows repo wizard hint when open', () => {
+    render(<StatusBar repo="" file="" wizardOpen />);
+    expect(screen.getByText('Open or create a blog content repository.')).toBeInTheDocument();
   });
 });

--- a/blog-writer/frontend/src/pages/RepoWizard.css
+++ b/blog-writer/frontend/src/pages/RepoWizard.css
@@ -1,4 +1,10 @@
 /* Copyright (c) 2025 blog-writer authors */
+.repo-wizard {
+  width: 400px;
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+}
 .tabs {
   display: flex;
 }
@@ -14,6 +20,15 @@
 .tabs .active {
   background-color: #eee;
 }
+.tabs button.hovered {
+  background-color: #ddd;
+}
+.open-tab,
+.create-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
 .open-tab table {
   width: 100%;
   border-collapse: collapse;
@@ -22,4 +37,13 @@
 .open-tab td {
   border: 1px solid #888;
   padding: 0.25rem;
+}
+.create-tab button {
+  align-self: flex-end;
+  margin-top: 0.5rem;
+}
+.hint {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  text-align: left;
 }

--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -14,6 +14,7 @@ interface RepoWizardProps {
 
 export default function RepoWizard({ onOpen }: RepoWizardProps) {
   const [tab, setTab] = useState<'open' | 'create'>('open');
+  const [hover, setHover] = useState<'open' | 'create' | null>(null);
   const [recent, setRecent] = useState<RecentRepo[]>([]);
   const [parentDir, setParentDir] = useState('');
   const [repoName, setRepoName] = useState('');
@@ -58,17 +59,21 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
   };
 
   return (
-    <div className="repo-wizard">
+    <div className="repo-wizard" data-testid="repo-wizard" style={{ width: '400px', height: '300px' }}>
       <div className="tabs">
         <button
-          className={tab === 'open' ? 'active' : 'inactive'}
+          className={`${tab === 'open' ? 'active' : 'inactive'} ${hover === 'open' ? 'hovered' : ''}`}
           onClick={() => setTab('open')}
+          onMouseEnter={() => setHover('open')}
+          onMouseLeave={() => setHover(null)}
         >
           Open
         </button>
         <button
-          className={tab === 'create' ? 'active' : 'inactive'}
+          className={`${tab === 'create' ? 'active' : 'inactive'} ${hover === 'create' ? 'hovered' : ''}`}
           onClick={() => setTab('create')}
+          onMouseEnter={() => setHover('create')}
+          onMouseLeave={() => setHover(null)}
         >
           Create
         </button>
@@ -92,6 +97,7 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
               ))}
             </tbody>
           </table>
+          <p className="hint">Select or create a repository to begin.</p>
         </div>
       )}
       {tab === 'create' && (
@@ -108,6 +114,7 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
             onChange={(e) => setRemote(e.target.value)}
           />
           <button onClick={handleCreate}>Create</button>
+          <p className="hint">Choose a parent folder and repository name.</p>
         </div>
       )}
     </div>

--- a/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
+++ b/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
@@ -2,19 +2,21 @@
 // SPDX-License-Identifier: MIT
 /// <reference types="vitest" />
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-vi.mock('../../wailsjs/go/services/RepoService', () => ({
-  Recent: () => Promise.resolve([{ path: 'r1', lastOpened: '2024-01-01T00:00:00Z' }]),
-  Open: vi.fn().mockResolvedValue(undefined),
-  Create: vi.fn()
-}));
 import RepoWizard from '../RepoWizard';
 
 /**
  * RepoWizard interaction tests.
  */
 describe('RepoWizard', () => {
+  beforeEach(() => {
+    const svc = (window as any).go.services.RepoService;
+    svc.Recent.mockResolvedValue([{ path: 'r1', lastOpened: '2024-01-01T00:00:00Z' }]);
+    svc.Open.mockResolvedValue(undefined);
+    svc.Create.mockResolvedValue(undefined);
+  });
+
   it('defaults to Open tab and opens repo on double click', async () => {
     const onOpen = vi.fn();
     render(<RepoWizard onOpen={onOpen} />);
@@ -27,5 +29,37 @@ describe('RepoWizard', () => {
     render(<RepoWizard onOpen={vi.fn()} />);
     fireEvent.click(screen.getByText('Create'));
     expect(screen.getByPlaceholderText('Repository Name')).toBeInTheDocument();
+  });
+
+  it('shows helpful hints on tabs', () => {
+    render(<RepoWizard onOpen={vi.fn()} />);
+    expect(screen.getByText(/Select or create/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Create'));
+    expect(screen.getByText(/Choose a parent folder/)).toBeInTheDocument();
+  });
+
+  it('places SSH URL below file picker with create button below and right', () => {
+    render(<RepoWizard onOpen={vi.fn()} />);
+    fireEvent.click(screen.getByText('Create'));
+    const boxes = screen.getAllByRole('textbox');
+    expect(boxes[1]).toHaveAttribute('placeholder', 'SSH URL (optional)');
+    const button = screen.getAllByText('Create')[1];
+    const hint = screen.getByText(/Choose a parent folder/);
+    expect(button.nextElementSibling).toBe(hint);
+  });
+
+  it('highlights tab on hover', () => {
+    render(<RepoWizard onOpen={vi.fn()} />);
+    const openTab = screen.getByText('Open');
+    fireEvent.mouseEnter(openTab);
+    expect(openTab).toHaveClass('hovered');
+    fireEvent.mouseLeave(openTab);
+    expect(openTab).not.toHaveClass('hovered');
+  });
+
+  it('has fixed dimensions', () => {
+    render(<RepoWizard onOpen={vi.fn()} />);
+    const wizard = screen.getByTestId('repo-wizard');
+    expect(wizard).toHaveStyle({ width: '400px', height: '300px' });
   });
 });

--- a/blog-writer/frontend/src/test/setup.ts
+++ b/blog-writer/frontend/src/test/setup.ts
@@ -1,2 +1,17 @@
 // Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+(window as any).go = {
+  services: {
+    RepoService: {
+      Recent: vi.fn(),
+      Open: vi.fn(),
+      Create: vi.fn()
+    },
+    TreeService: {
+      List: vi.fn()
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add modal overlay backdrop
- stretch editor to fill available height
- refine repo wizard layout with hints and hover effects
- show repo wizard message in status bar and keep nav on right

## Testing
- `npm --prefix blog-writer/frontend test`

------
https://chatgpt.com/codex/tasks/task_b_689ff1d160848332b52a417864268220