### PR TITLE
Normalize status bar path separators

### DIFF
--- a/blog-writer/frontend/src/components/StatusBar.tsx
+++ b/blog-writer/frontend/src/components/StatusBar.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import './StatusBar.css';
+import { normalizePath } from '../utils/normalizePath';
 
 /**
  * StatusBar displays the current repository and file being edited.
@@ -17,10 +18,12 @@ interface StatusBarProps {
 }
 
 export default function StatusBar({ repo, file, wizardOpen }: StatusBarProps): JSX.Element {
+  const repoPath = repo ? normalizePath(repo) : '';
+  const filePath = file ? normalizePath(file) : '';
   const text = wizardOpen
     ? 'Open or create a blog content repository.'
     : repo
-    ? `${repo} - ${file}`
+    ? `${repoPath} - ${filePath}`
     : '';
   return <div className="status-bar">{text}</div>;
 }

--- a/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
@@ -3,6 +3,7 @@
 /// <reference types="vitest" />
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import path from 'path';
 import '@testing-library/jest-dom/vitest';
 import StatusBar from '../StatusBar';
 
@@ -10,9 +11,12 @@ import StatusBar from '../StatusBar';
  * Render tests for StatusBar component.
  */
 describe('StatusBar', () => {
-  it('shows repository and file info', () => {
-    render(<StatusBar repo="/repo" file="file.txt" wizardOpen={false} />);
-    expect(screen.getByText('/repo - file.txt')).toBeInTheDocument();
+  it('shows repository and file info using host path separators', () => {
+    const repo = 'one/two\\three';
+    const file = 'sub\\file.txt';
+    const expected = `${path.normalize(repo)} - ${path.normalize(file)}`;
+    render(<StatusBar repo={repo} file={file} wizardOpen={false} />);
+    expect(screen.getByText(expected)).toBeInTheDocument();
   });
 
   it('shows repo wizard hint when open', () => {

--- a/blog-writer/frontend/src/utils/__tests__/normalizePath.test.ts
+++ b/blog-writer/frontend/src/utils/__tests__/normalizePath.test.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 blog-writer authors
+// SPDX-License-Identifier: MIT
+/// <reference types="vitest" />
+
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { normalizePath } from '../normalizePath';
+
+/**
+ * Tests for normalizePath utility.
+ */
+describe('normalizePath', () => {
+  it('converts mixed separators to host format', () => {
+    const input = 'a/b\\c';
+    const expected = path.normalize(input);
+    expect(normalizePath(input)).toBe(expected);
+  });
+});
+

--- a/blog-writer/frontend/src/utils/normalizePath.ts
+++ b/blog-writer/frontend/src/utils/normalizePath.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 blog-writer authors
+// SPDX-License-Identifier: MIT
+
+import path from 'path';
+
+/**
+ * Normalize a filesystem path using the host platform's separator.
+ *
+ * @param p - Path to normalize.
+ * @returns Path formatted for the current operating system.
+ */
+export function normalizePath(p: string): string {
+  return path.normalize(p);
+}
+


### PR DESCRIPTION
## Summary
- normalize displayed repository and file paths to match host OS
- add reusable `normalizePath` utility
- cover path normalization with unit tests

## Testing
- `npm test --prefix blog-writer/frontend`

------
https://chatgpt.com/codex/tasks/task_b_689ff6bf7b44833282c3cc5f8528495c