### PR TITLE
fix: left navigation pane layout

### DIFF
--- a/blog-writer/frontend/src/App.tsx
+++ b/blog-writer/frontend/src/App.tsx
@@ -12,14 +12,16 @@ import StatusBar from './components/StatusBar';
 import FileTree from './components/FileTree';
 import logo from './assets/images/logo-universal.png';
 
-/**
- * App renders the WYSIWYG editor with a modal repo wizard.
- */
+  /**
+   * App renders the WYSIWYG editor with a modal repo wizard and
+   * a fixed-width file navigation tree.
+   */
 export default function App(): JSX.Element {
   const [showRepoWizard, setShowRepoWizard] = useState(true);
   const [showLogo, setShowLogo] = useState(true);
   const [repo, setRepo] = useState('');
   const [file, setFile] = useState('');
+  const editorStyle: React.CSSProperties = { flex: 1, display: 'flex' };
 
   useEffect(() => {
     const t = setTimeout(() => setShowLogo(false), 15000);
@@ -32,18 +34,18 @@ export default function App(): JSX.Element {
   };
 
   return (
-    <div id="App" className="app-window">
-      <MenuBar />
-      <div className="main-area">
-        <div className="editor-container">
-          <Editor />
+      <div id="App" className="app-window">
+        <MenuBar />
+        <div className="main-area">
+          <FileTree repo={repo} onSelect={setFile} />
+          <div className="editor-container" style={editorStyle}>
+            <Editor />
+          </div>
         </div>
-        <FileTree repo={repo} onSelect={setFile} />
+        <StatusBar repo={repo} file={file} wizardOpen={showRepoWizard} />
+        <Modal open={showRepoWizard}>
+          {showLogo ? <img src={logo} alt="logo" /> : <RepoWizard onOpen={handleOpen} />}
+        </Modal>
       </div>
-      <StatusBar repo={repo} file={file} wizardOpen={showRepoWizard} />
-      <Modal open={showRepoWizard}>
-        {showLogo ? <img src={logo} alt="logo" /> : <RepoWizard onOpen={handleOpen} />}
-      </Modal>
-    </div>
   );
 }

--- a/blog-writer/frontend/src/__tests__/App.test.tsx
+++ b/blog-writer/frontend/src/__tests__/App.test.tsx
@@ -33,12 +33,25 @@ describe('App', () => {
     vi.useRealTimers();
   });
 
-  it('keeps navigation pane on right when no repository open', () => {
-    render(<App />);
-    const tree = document.querySelector('.main-area .file-tree');
-    expect(tree).not.toBeNull();
-    expect(tree?.previousElementSibling?.className).toContain('editor-container');
-  });
+    it('positions FileTree on the left with fixed width', () => {
+      render(<App />);
+      const tree = document.querySelector('.main-area .file-tree') as HTMLElement;
+      expect(tree).not.toBeNull();
+      const editor = tree.nextElementSibling as HTMLElement;
+      expect(editor.className).toContain('editor-container');
+      const treeStyle = getComputedStyle(tree);
+      expect(treeStyle.width).toBe('150px');
+      expect(treeStyle.flexGrow).toBe('0');
+      expect(treeStyle.flexShrink).toBe('0');
+    });
+
+    it('allows the editor to grow and shrink with the window', () => {
+      render(<App />);
+      const editor = document.querySelector('.editor-container') as HTMLElement;
+      const style = getComputedStyle(editor);
+      expect(style.flexGrow).toBe('1');
+      expect(style.flexShrink).toBe('1');
+    });
 
   it('shows repo wizard status message', () => {
     render(<App />);

--- a/blog-writer/frontend/src/components/FileTree.css
+++ b/blog-writer/frontend/src/components/FileTree.css
@@ -1,12 +1,11 @@
 /* Copyright (c) 2025 blog-writer authors */
 
-.file-tree {
-  width: 200px;
-  overflow-y: auto;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
+  .file-tree {
+    overflow-y: auto;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
 .file-tree li button {
   display: block;
   width: 100%;

--- a/blog-writer/frontend/src/components/FileTree.tsx
+++ b/blog-writer/frontend/src/components/FileTree.tsx
@@ -16,6 +16,7 @@ interface FileTreeProps {
 }
 
 export default function FileTree({ repo, onSelect }: FileTreeProps): JSX.Element {
+  const NAV_WIDTH = 150; // Navigation pane fixed width in pixels.
   const [files, setFiles] = useState<string[]>([]);
   useEffect(() => {
     if (repo) {
@@ -24,13 +25,16 @@ export default function FileTree({ repo, onSelect }: FileTreeProps): JSX.Element
       setFiles([]);
     }
   }, [repo]);
-  return (
-    <ul className="file-tree">
-      {files.map(f => (
-        <li key={f}>
-          <button onClick={() => onSelect(f)}>{f}</button>
-        </li>
-      ))}
-    </ul>
-  );
+    return (
+      <ul
+        className="file-tree"
+        style={{ width: `${NAV_WIDTH}px`, flex: `0 0 ${NAV_WIDTH}px` }}
+      >
+        {files.map(f => (
+          <li key={f}>
+            <button onClick={() => onSelect(f)}>{f}</button>
+          </li>
+        ))}
+      </ul>
+    );
 }


### PR DESCRIPTION
## Summary
- place FileTree navigation on the left with fixed 150px width
- allow editor area to flex-grow and fill remaining space
- test layout ensuring FileTree width and editor flex behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689ff761932c83329432fe12eddab3d6