### PR TITLE
Add stylistic border and shadow to modal

### DIFF
--- a/blog-writer/frontend/src/__tests__/Modal.test.tsx
+++ b/blog-writer/frontend/src/__tests__/Modal.test.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+/// <reference types="vitest" />
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import Modal from '../components/Modal';
+
+/**
+ * Unit tests for the Modal component verifying stylistic requirements.
+ */
+describe('Modal', () => {
+  it('applies an outset border and 10px offset shadow', () => {
+    render(<Modal open>content</Modal>);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.style.borderStyle).toBe('outset');
+    expect(dialog.style.boxShadow.startsWith('10px 10px')).toBe(true);
+  });
+});

--- a/blog-writer/frontend/src/components/Modal.tsx
+++ b/blog-writer/frontend/src/components/Modal.tsx
@@ -4,7 +4,9 @@
 import React from 'react';
 
 /**
- * Modal wraps content in a dialog element displayed above the main window.
+ * Modal wraps content in a dialog element displayed above the main window with a
+ * visual distinction including an outset border and a drop shadow offset by
+ * 10 pixels to the right and bottom.
  */
 interface ModalProps {
   /** True if the modal should be displayed. */
@@ -16,8 +18,17 @@ interface ModalProps {
 export default function Modal({ open, children }: ModalProps): JSX.Element | null {
   if (!open) return null;
   return (
-    <dialog open style={{ borderRadius: '5px' }}>
+    <dialog open style={dialogStyle}>
       {children}
     </dialog>
   );
 }
+
+/**
+ * dialogStyle defines the modal's visual appearance.
+ */
+const dialogStyle: React.CSSProperties = {
+  borderRadius: '5px',
+  border: '2px outset',
+  boxShadow: '10px 10px 10px rgba(0,0,0,0.2)'
+};


### PR DESCRIPTION
## Summary
- add reusable modal style with outset border and 10px drop shadow
- verify modal styling through new unit test

## Testing
- `npm test src/__tests__/Modal.test.tsx`
- `npm test -- --run` (fails: TypeError: Cannot read properties of undefined (reading 'services'))
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689ff4018fd88332baeb7f23ea8ddea1