### PR TITLE
fix: add modal title and browser-safe path normalization

### DIFF
--- a/blog-writer/frontend/src/App.tsx
+++ b/blog-writer/frontend/src/App.tsx
@@ -43,7 +43,7 @@ export default function App(): JSX.Element {
           </div>
         </div>
         <StatusBar repo={repo} file={file} wizardOpen={showRepoWizard} />
-        <Modal open={showRepoWizard}>
+        <Modal open={showRepoWizard} title="Repository Wizard">
           {showLogo ? <img src={logo} alt="logo" /> : <RepoWizard onOpen={handleOpen} />}
         </Modal>
       </div>

--- a/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
@@ -3,9 +3,9 @@
 /// <reference types="vitest" />
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
-import path from 'path';
 import '@testing-library/jest-dom/vitest';
 import StatusBar from '../StatusBar';
+import { normalizePath } from '../../utils/normalizePath';
 
 /**
  * Render tests for StatusBar component.
@@ -14,7 +14,7 @@ describe('StatusBar', () => {
   it('shows repository and file info using host path separators', () => {
     const repo = 'one/two\\three';
     const file = 'sub\\file.txt';
-    const expected = `${path.normalize(repo)} - ${path.normalize(file)}`;
+    const expected = `${normalizePath(repo)} - ${normalizePath(file)}`;
     render(<StatusBar repo={repo} file={file} wizardOpen={false} />);
     expect(screen.getByText(expected)).toBeInTheDocument();
   });

--- a/blog-writer/frontend/src/types/react-overrides.d.ts
+++ b/blog-writer/frontend/src/types/react-overrides.d.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 blog-writer authors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Augment React's input attributes to support the non-standard `webkitdirectory`
+ * attribute used for directory selection in file input elements.
+ */
+import 'react';
+
+declare module 'react' {
+  interface InputHTMLAttributes<T> {
+    /**
+     * When present on an `<input type="file">` element, enables directory
+     * selection instead of a single file.
+     */
+    webkitdirectory?: string;
+  }
+}
+
+export {};
+

--- a/blog-writer/frontend/src/utils/__tests__/normalizePath.test.ts
+++ b/blog-writer/frontend/src/utils/__tests__/normalizePath.test.ts
@@ -3,7 +3,6 @@
 /// <reference types="vitest" />
 
 import { describe, it, expect } from 'vitest';
-import path from 'path';
 import { normalizePath } from '../normalizePath';
 
 /**
@@ -12,7 +11,11 @@ import { normalizePath } from '../normalizePath';
 describe('normalizePath', () => {
   it('converts mixed separators to host format', () => {
     const input = 'a/b\\c';
-    const expected = path.normalize(input);
+    const sep =
+      typeof navigator !== 'undefined' && /windows/i.test(navigator.userAgent)
+        ? '\\'
+        : '/';
+    const expected = ['a', 'b', 'c'].join(sep);
     expect(normalizePath(input)).toBe(expected);
   });
 });

--- a/blog-writer/frontend/src/utils/normalizePath.ts
+++ b/blog-writer/frontend/src/utils/normalizePath.ts
@@ -1,15 +1,32 @@
 // Copyright (c) 2025 blog-writer authors
 // SPDX-License-Identifier: MIT
 
-import path from 'path';
-
 /**
  * Normalize a filesystem path using the host platform's separator.
+ *
+ * This implementation is browser friendly and avoids relying on Node.js
+ * built-ins so it can be used within the frontend bundle and during unit
+ * tests. It collapses duplicate separators, resolves ``.`` and ``..``
+ * segments and converts mixed ``/`` and ``\\`` separators to the correct
+ * form for the current operating system.
  *
  * @param p - Path to normalize.
  * @returns Path formatted for the current operating system.
  */
 export function normalizePath(p: string): string {
-  return path.normalize(p);
+  const isWindows =
+    typeof navigator !== 'undefined' &&
+    /windows/i.test(navigator.userAgent);
+  const sep = isWindows ? '\\' : '/';
+  const segments = p.replace(/[\\/]+/g, '/').split('/');
+  const stack: string[] = [];
+
+  for (const segment of segments) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') stack.pop();
+    else stack.push(segment);
+  }
+
+  return stack.join(sep);
 }
 


### PR DESCRIPTION
## Summary
- add missing title to modal invocation in `App`
- replace Node `path` module with browser-safe `normalizePath` utility and update tests
- extend React input attributes to allow `webkitdirectory`

## Testing
- `npx --prefix blog-writer/frontend tsc --noEmit -p blog-writer/frontend` *(fails: Cannot find namespace 'JSX')*
- `npm --prefix blog-writer/frontend test` *(fails: react_dom_1.default.findDOMNode is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_689ffb085b1483328de2f108da71906a