### PR TITLE
Fix modal layering and editor width

### DIFF
--- a/blog-writer/frontend/src/App.css
+++ b/blog-writer/frontend/src/App.css
@@ -19,6 +19,7 @@
 .editor-container .ql-container {
     flex: 1;
     height: 100%;
+    width: 100%;
 }
 
 .editor-container .ql-editor {

--- a/blog-writer/frontend/src/__tests__/App.test.tsx
+++ b/blog-writer/frontend/src/__tests__/App.test.tsx
@@ -45,7 +45,7 @@ describe('App', () => {
       expect(treeStyle.flexShrink).toBe('0');
     });
 
-    it('allows the editor to grow and shrink with the window', () => {
+  it('allows the editor to grow and shrink with the window', () => {
       render(<App />);
       const editor = document.querySelector('.editor-container') as HTMLElement;
       const style = getComputedStyle(editor);
@@ -58,6 +58,13 @@ describe('App', () => {
     expect(screen.getByText('Open or create a blog content repository.')).toBeInTheDocument();
   });
 
+  it('expands the editor to the right edge', () => {
+    render(<App />);
+    const root = document.querySelector('.editor-container > div') as HTMLElement;
+    const style = getComputedStyle(root);
+    expect(style.width).toBe('100%');
+  });
+
   it('renders a centered modal logo', () => {
     render(<App />);
     const overlay = screen.getByTestId('modal-overlay');
@@ -67,5 +74,20 @@ describe('App', () => {
       justifyContent: 'center'
     });
     expect(screen.getByAltText('logo')).toBeInTheDocument();
+  });
+
+  it('styles the modal overlay and title bar', () => {
+    render(<App />);
+    const overlay = screen.getByTestId('modal-overlay');
+    expect(overlay).toHaveStyle({
+      position: 'fixed',
+      zIndex: '1000'
+    });
+    const header = screen.getByText('Repository Wizard');
+    expect(header).toHaveStyle({
+      backgroundColor: 'rgb(27, 38, 54)',
+      color: 'rgb(255, 255, 255)'
+    });
+    expect((header as HTMLElement).style.borderBottom).toBe('');
   });
 });

--- a/blog-writer/frontend/src/components/Editor.tsx
+++ b/blog-writer/frontend/src/components/Editor.tsx
@@ -10,7 +10,14 @@ import 'react-quill/dist/quill.snow.css';
  */
 export const Editor: React.FC = () => {
   const [value, setValue] = useState<string>('');
-  return <ReactQuill theme="snow" value={value} onChange={setValue} style={{ height: '100%' }} />;
+  return (
+    <ReactQuill
+      theme="snow"
+      value={value}
+      onChange={setValue}
+      style={{ height: '100%', width: '100%' }}
+    />
+  );
 };
 
 export default Editor;

--- a/blog-writer/frontend/src/components/Modal.tsx
+++ b/blog-writer/frontend/src/components/Modal.tsx
@@ -23,19 +23,10 @@ export default function Modal({ open, title, children }: ModalProps): JSX.Elemen
     <div
       className="modal-overlay"
       data-testid="modal-overlay"
-      style={dialogStyle}
+      style={overlayStyle}
     >
-      <dialog open style={{ borderRadius: '5px', padding: 0 }}>
-        <div
-          style={{
-            textAlign: 'center',
-            fontFamily: 'system-ui, sans-serif',
-            padding: '0.5rem',
-            borderBottom: '1px solid black',
-          }}
-        >
-          {title}
-        </div>
+      <dialog open style={dialogStyle}>
+        <div style={headerStyle}>{title}</div>
         {children}
       </dialog>
     </div>
@@ -43,10 +34,38 @@ export default function Modal({ open, title, children }: ModalProps): JSX.Elemen
 }
 
 /**
+ * overlayStyle positions and styles the translucent backdrop.
+ */
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  height: '100vh',
+  zIndex: 1000,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: 'rgba(0, 0, 0, 0.5)'
+};
+
+/**
  * dialogStyle defines the modal's visual appearance.
  */
 const dialogStyle: React.CSSProperties = {
   borderRadius: '5px',
+  padding: 0,
   border: '2px outset',
   boxShadow: '10px 10px 10px rgba(0,0,0,0.2)'
+};
+
+/**
+ * headerStyle matches the app window styling without a separating border.
+ */
+const headerStyle: React.CSSProperties = {
+  textAlign: 'center',
+  fontFamily: '"Nunito", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+  padding: '0.5rem',
+  backgroundColor: 'rgba(27, 38, 54, 1)',
+  color: 'white'
 };


### PR DESCRIPTION
## Summary
- ensure modal overlay covers viewport and matches app window styling
- expand editor to fill available width and remove tab divider
- update tests for overlay and editor layout

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_68a0020c850c833292cdef7b7e3fc2f9