### PR TITLE
Ensure blank recent rows maintain height in RepoWizard

### DIFF
--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -17,6 +17,17 @@ interface RepoWizardProps {
   onOpen: (path: string) => void;
 }
 
+/**
+ * Render table cell text, using a non-breaking space to maintain row height
+ * when the value is blank.
+ *
+ * @param value - Text content for a table cell.
+ * @returns The provided value or a non-breaking space if empty.
+ */
+function cellText(value: string): string {
+  return value || '\u00A0';
+}
+
 export default function RepoWizard({ onOpen }: RepoWizardProps) {
   const [tab, setTab] = useState<'open' | 'create'>('open');
   const [hover, setHover] = useState<'open' | 'create' | null>(null);
@@ -118,8 +129,12 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
                   data-testid="recent-row"
                   onDoubleClick={r.path ? () => openRecent(r.path) : undefined}
                 >
-                  <td>{r.path}</td>
-                  <td>{r.lastOpened ? new Date(r.lastOpened).toLocaleString() : ''}</td>
+                  <td>{cellText(r.path)}</td>
+                  <td>
+                    {cellText(
+                      r.lastOpened ? new Date(r.lastOpened).toLocaleString() : ''
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
+++ b/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
@@ -80,11 +80,16 @@ describe('RepoWizard', () => {
     expect(hintCreate.parentElement?.lastElementChild).toBe(hintCreate);
   });
 
-  it('renders five recent placeholders when empty', async () => {
+  it('renders five placeholders with consistent height when empty', async () => {
     const svc = (window as any).go.services.RepoService;
     svc.Recent.mockResolvedValue([]);
     render(<RepoWizard onOpen={vi.fn()} />);
     const rows = await screen.findAllByTestId('recent-row');
     expect(rows).toHaveLength(5);
+    for (const row of rows) {
+      const cells = row.querySelectorAll('td');
+      expect(cells[0].textContent).toBe('\u00A0');
+      expect(cells[1].textContent).toBe('\u00A0');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Preserve row height in RepoWizard recent list by substituting non-breaking spaces for empty cells
- Add coverage verifying placeholder rows have consistent height

## Testing
- `npm --prefix blog-writer/frontend test -- --run`
- `go test ./...`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_b_68a0843179288332a36934cdf883b6e7