### PR TITLE
Add depth to RepoWizard tabs

### DIFF
--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -74,10 +74,14 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
     }
   };
 
+  const tabBorderColor = '#555';
   const tabStyle: React.CSSProperties = {
     flex: 1,
     padding: '0.5rem',
-    border: 'none',
+    borderTop: `1px outset ${tabBorderColor}`,
+    borderLeft: `1px outset ${tabBorderColor}`,
+    borderRight: `1px outset ${tabBorderColor}`,
+    borderBottom: '1px solid black',
     borderTopLeftRadius: '5px',
     borderTopRightRadius: '5px',
     cursor: 'pointer',

--- a/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
+++ b/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
@@ -67,15 +67,23 @@ describe('RepoWizard', () => {
     render(<RepoWizard onOpen={vi.fn()} />);
     const openTab = screen.getByText('Open');
     const createTab = screen.getByText('Create');
-    expect(openTab).toHaveStyle('border-top-left-radius: 5px; border-top-right-radius: 5px; margin: 0px;');
-    expect(createTab).toHaveStyle('border-top-left-radius: 5px; border-top-right-radius: 5px; margin: 0px;');
-    expect(createTab).toHaveStyle('border-bottom: 1px solid black');
+    expect(openTab).toHaveStyle(
+      'border-top: 1px outset #555; border-left: 1px outset #555; border-right: 1px outset #555; border-top-left-radius: 5px; border-top-right-radius: 5px; margin: 0px;'
+    );
+    expect(createTab).toHaveStyle(
+      'border-top: 1px outset #555; border-left: 1px outset #555; border-right: 1px outset #555; border-top-left-radius: 5px; border-top-right-radius: 5px; margin: 0px; border-bottom: 1px solid black'
+    );
     const picker = screen.getAllByTestId('path-picker')[0];
     expect(picker).toHaveStyle({ height: '25px', marginTop: '20px' });
     const hint = screen.getByText(/Select or create/);
     expect(hint.parentElement?.lastElementChild).toBe(hint);
     fireEvent.click(createTab);
-    expect(openTab).toHaveStyle('border-bottom: 1px solid black');
+    expect(createTab).toHaveStyle(
+      'border-top: 1px outset #555; border-left: 1px outset #555; border-right: 1px outset #555'
+    );
+    expect(openTab).toHaveStyle(
+      'border-top: 1px outset #555; border-left: 1px outset #555; border-right: 1px outset #555; border-bottom: 1px solid black'
+    );
     const hintCreate = screen.getByText(/Choose a parent folder/);
     expect(hintCreate.parentElement?.lastElementChild).toBe(hintCreate);
   });


### PR DESCRIPTION
## Summary
- add outset dark grey borders on RepoWizard tabs for depth
- test tab borders and ensure styling remains consistent when switching tabs

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a08846185c83329d752eef9a2ae866