### PR TITLE
Remove Quill toolbar from Editor component

### DIFF
--- a/blog-writer/frontend/src/components/Editor.tsx
+++ b/blog-writer/frontend/src/components/Editor.tsx
@@ -6,6 +6,11 @@ import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
 /**
+ * Disable the default Quill toolbar since controls live in MenuBar.
+ */
+const quillModules = { toolbar: false };
+
+/**
  * Editor provides a basic React Quill WYSIWYG editor for authoring blog content.
  */
 export const Editor: React.FC = () => {
@@ -15,6 +20,7 @@ export const Editor: React.FC = () => {
       theme="snow"
       value={value}
       onChange={setValue}
+      modules={quillModules}
       style={{ height: '100%', width: '100%' }}
     />
   );

--- a/blog-writer/frontend/src/components/__tests__/Editor.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/Editor.test.tsx
@@ -10,15 +10,22 @@ import Editor from '../Editor';
  * Render tests for the WYSIWYG editor.
  */
 describe('Editor', () => {
-  it('renders a textbox for content editing', () => {
+  it('renders an editable content area', () => {
     render(<Editor />);
-    const textbox = screen.getByRole('textbox');
-    expect(textbox).toBeInTheDocument();
+    const editor = document.querySelector('.ql-editor') as HTMLElement;
+    expect(editor).toBeInTheDocument();
+    expect(editor.getAttribute('contenteditable')).toBe('true');
   });
 
   it('stretches to full height', () => {
     render(<Editor />);
     const wrapper = document.querySelector('.ql-container')?.parentElement as HTMLElement;
     expect(wrapper).toHaveStyle({ height: '100%' });
+  });
+
+  it('does not render a toolbar', () => {
+    render(<Editor />);
+    const toolbar = document.querySelector('.ql-toolbar');
+    expect(toolbar).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Disable ReactQuill's built-in toolbar in `Editor` so controls live exclusively in `MenuBar`
- Cover `Editor` behavior with tests ensuring editable area exists and toolbar is absent

## Testing
- `cd blog-writer/frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a088d51aec83328d70359312d33c45