### PR TITLE
Add reusable grid component for recent repositories

### DIFF
--- a/blog-writer/frontend/src/components/Grid.css
+++ b/blog-writer/frontend/src/components/Grid.css
@@ -1,0 +1,12 @@
+/* Copyright (c) 2025 Sam Caldwell */
+.grid {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+.grid th,
+.grid td {
+  padding: 0.25rem;
+}

--- a/blog-writer/frontend/src/components/Grid.tsx
+++ b/blog-writer/frontend/src/components/Grid.tsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Sam Caldwell
+/**
+ * Grid component renders tabular data with consistent styling.
+ */
+import React from 'react';
+import './Grid.css';
+
+/** Props for the Grid component. */
+interface GridProps {
+  /** Column headers for the grid. */
+  headers: string[];
+  /** Rows of string data to display. */
+  rows: string[][];
+  /** Optional test id for the table element. */
+  dataTestId?: string;
+  /** Optional test id applied to each row. */
+  rowTestId?: string;
+  /** Optional handler for row double-click events. */
+  onRowDoubleClick?: (index: number) => void;
+}
+
+/**
+ * Grid displays headers and rows with equal column widths and specific borders.
+ */
+export function Grid({ headers, rows, dataTestId, rowTestId, onRowDoubleClick }: GridProps): JSX.Element {
+  const columnWidth = `${100 / headers.length}%`;
+  return (
+    <table
+      className="grid"
+      data-testid={dataTestId}
+      style={{ borderStyle: 'outset', borderWidth: '1px', borderRadius: '5px' }}
+    >
+      <thead>
+        <tr>
+          {headers.map(h => (
+            <th
+              key={h}
+              style={{
+                width: columnWidth,
+                backgroundColor: '#ddd',
+                borderStyle: 'outset',
+                borderWidth: '1px',
+              }}
+            >
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr
+            key={i}
+            data-testid={rowTestId}
+            onDoubleClick={onRowDoubleClick ? () => onRowDoubleClick(i) : undefined}
+          >
+            {row.map((cell, j) => (
+              <td
+                key={j}
+                style={{ backgroundColor: '#fff', borderStyle: 'inset', borderWidth: '1px' }}
+              >
+                {cell || '\u00A0'}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default Grid;

--- a/blog-writer/frontend/src/components/__tests__/Grid.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/Grid.test.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Sam Caldwell
+/**
+ * Tests for Grid component ensuring styling and layout expectations.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Grid from '../Grid';
+
+/**
+ * Verify grid styling such as borders, radius, and column widths.
+ */
+describe('Grid', () => {
+  it('applies border, radius, and equal column widths with cell styles', () => {
+    const headers = ['A', 'B'];
+    const rows = [['1', '2']];
+    render(<Grid headers={headers} rows={rows} dataTestId="grid" rowTestId="row" />);
+    const grid = screen.getByTestId('grid');
+    expect(grid).toHaveStyle({ borderStyle: 'outset', borderRadius: '5px' });
+
+    const headerCells = screen.getAllByRole('columnheader');
+    const dataCells = screen.getAllByRole('cell');
+
+    headerCells.forEach(h => {
+      expect(h).toHaveStyle({ backgroundColor: '#ddd', width: '50%', borderStyle: 'outset' });
+    });
+    dataCells.forEach(d => {
+      expect(d).toHaveStyle({ backgroundColor: '#fff', borderStyle: 'inset' });
+    });
+  });
+});

--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -1,7 +1,8 @@
-// Copyright (c) 2024 blog-writer authors
+// Copyright (c) 2025 blog-writer authors
 import { useEffect, useState } from 'react';
 import { Create, Open, Recent } from '../../wailsjs/go/services/RepoService';
 import PathPicker from '../components/PathPicker';
+import Grid from '../components/Grid';
 import './RepoWizard.css';
 
 interface RecentRepo {
@@ -15,17 +16,6 @@ interface RecentRepo {
 interface RepoWizardProps {
   /** Callback when a repository has been opened. */
   onOpen: (path: string) => void;
-}
-
-/**
- * Render table cell text, using a non-breaking space to maintain row height
- * when the value is blank.
- *
- * @param value - Text content for a table cell.
- * @returns The provided value or a non-breaking space if empty.
- */
-function cellText(value: string): string {
-  return value || '\u00A0';
 }
 
 export default function RepoWizard({ onOpen }: RepoWizardProps) {
@@ -85,6 +75,10 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
   };
   const rows: RecentRepo[] = [...recent];
   while (rows.length < 5) rows.push({ path: '', lastOpened: '' } as RecentRepo);
+  const gridRows = rows.map(r => [
+    r.path,
+    r.lastOpened ? new Date(r.lastOpened).toLocaleString() : '',
+  ]);
 
   return (
     <div className="repo-wizard" data-testid="repo-wizard" style={{ width: '400px', height: '300px' }}>
@@ -115,30 +109,16 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
             data-testid="path-picker"
             style={{ height: '25px', marginTop: '20px' }}
           />
-          <table>
-            <thead>
-              <tr>
-                <th>Path</th>
-                <th>Last Opened</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((r, i) => (
-                <tr
-                  key={i}
-                  data-testid="recent-row"
-                  onDoubleClick={r.path ? () => openRecent(r.path) : undefined}
-                >
-                  <td>{cellText(r.path)}</td>
-                  <td>
-                    {cellText(
-                      r.lastOpened ? new Date(r.lastOpened).toLocaleString() : ''
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <Grid
+            headers={['Path', 'Last Opened']}
+            rows={gridRows}
+            dataTestId="recent-grid"
+            rowTestId="recent-row"
+            onRowDoubleClick={(i) => {
+              const r = rows[i];
+              if (r.path) openRecent(r.path);
+            }}
+          />
           <p className="hint" style={{ marginTop: 'auto' }}>
             Select or create a repository to begin.
           </p>

--- a/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
+++ b/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
@@ -92,4 +92,12 @@ describe('RepoWizard', () => {
       expect(cells[1].textContent).toBe('\u00A0');
     }
   });
+  it('uses Grid component with styled borders for recent repositories', async () => {
+    render(<RepoWizard onOpen={vi.fn()} />);
+    const grid = await screen.findByTestId('recent-grid');
+    expect(grid).toHaveStyle({ borderStyle: 'outset', borderRadius: '5px' });
+    const headers = grid.querySelectorAll('th');
+    const width = (headers[0] as HTMLElement).style.width;
+    headers.forEach(h => expect((h as HTMLElement).style.width).toBe(width));
+  });
 });


### PR DESCRIPTION
## Summary
- replace table in RepoWizard with reusable Grid component
- implement Grid with equal column widths, shaded headers, inset data cells, and outset border
- cover Grid and RepoWizard behavior with tests

## Testing
- `npx --prefix blog-writer/frontend tsc --noEmit -p blog-writer/frontend`
- `cd blog-writer/frontend && npx vitest run`
- `cd blog-writer/blog-writer && go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a087d9c3b88332a632a3b0e25379bd