### PR TITLE
feat: improve file tree and status bar

### DIFF
--- a/blog-writer/frontend/src/App.css
+++ b/blog-writer/frontend/src/App.css
@@ -9,6 +9,7 @@
 .main-area {
     flex: 1;
     display: flex;
+    overflow: hidden;
 }
 
 .editor-container {

--- a/blog-writer/frontend/src/components/FileTree.css
+++ b/blog-writer/frontend/src/components/FileTree.css
@@ -5,6 +5,7 @@
     margin: 0;
     padding: 0;
     list-style: none;
+    height: 100%;
   }
 .file-tree li button {
   display: block;

--- a/blog-writer/frontend/src/components/FileTree.tsx
+++ b/blog-writer/frontend/src/components/FileTree.tsx
@@ -25,16 +25,27 @@ export default function FileTree({ repo, onSelect }: FileTreeProps): JSX.Element
       setFiles([]);
     }
   }, [repo]);
+  const style: React.CSSProperties = {
+    width: `${NAV_WIDTH}px`,
+    flex: `0 0 ${NAV_WIDTH}px`,
+    height: '100%',
+  };
+  if (!repo) {
     return (
-      <ul
-        className="file-tree"
-        style={{ width: `${NAV_WIDTH}px`, flex: `0 0 ${NAV_WIDTH}px` }}
-      >
-        {files.map(f => (
-          <li key={f}>
-            <button onClick={() => onSelect(f)}>{f}</button>
-          </li>
-        ))}
+      <ul className="file-tree" style={style}>
+        <li>
+          <span aria-label="repository">📜</span>
+        </li>
       </ul>
     );
+  }
+  return (
+    <ul className="file-tree" style={style}>
+      {files.map(f => (
+        <li key={f}>
+          <button onClick={() => onSelect(f)}>{f}</button>
+        </li>
+      ))}
+    </ul>
+  );
 }

--- a/blog-writer/frontend/src/components/StatusBar.css
+++ b/blog-writer/frontend/src/components/StatusBar.css
@@ -3,6 +3,11 @@
 .status-bar {
   height: 24px;
   line-height: 24px;
-  background: #eee;
+  background: Canvas;
+  color: CanvasText;
   padding-left: 8px;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  color-scheme: light dark;
+  width: 100%;
 }

--- a/blog-writer/frontend/src/components/StatusBar.tsx
+++ b/blog-writer/frontend/src/components/StatusBar.tsx
@@ -25,5 +25,17 @@ export default function StatusBar({ repo, file, wizardOpen }: StatusBarProps): J
     : repo
     ? `${repoPath} - ${filePath}`
     : '';
-  return <div className="status-bar">{text}</div>;
+  const style: React.CSSProperties = {
+    fontFamily:
+      "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+    background: 'Canvas',
+    color: 'CanvasText',
+    colorScheme: 'light dark',
+    width: '100%',
+  };
+  return (
+    <div className="status-bar" style={style}>
+      {text}
+    </div>
+  );
 }

--- a/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
@@ -27,4 +27,15 @@ describe('FileTree', () => {
     render(<FileTree repo="" onSelect={onSelect} />);
     expect(screen.getByRole('list')).toBeInTheDocument();
   });
+
+  it('shows repository icon when no repository is open', () => {
+    render(<FileTree repo="" onSelect={() => {}} />);
+    expect(screen.getByLabelText('repository')).toBeInTheDocument();
+  });
+
+  it('limits its height to available space', () => {
+    const { container } = render(<FileTree repo="" onSelect={() => {}} />);
+    const list = container.querySelector('.file-tree') as HTMLElement;
+    expect(list).toHaveStyle('height: 100%');
+  });
 });

--- a/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
@@ -23,4 +23,12 @@ describe('StatusBar', () => {
     render(<StatusBar repo="" file="" wizardOpen />);
     expect(screen.getByText('Open or create a blog content repository.')).toBeInTheDocument();
   });
+
+  it('uses system fonts and colors', () => {
+    const { container } = render(<StatusBar repo="" file="" wizardOpen={false} />);
+    const bar = container.querySelector('.status-bar') as HTMLElement;
+    const styles = getComputedStyle(bar);
+    expect(styles.fontFamily.toLowerCase()).toContain('system-ui');
+    expect(styles.backgroundColor).not.toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- show repository icon when no repo is open in FileTree
- limit FileTree height and prevent overlap with StatusBar
- adopt system fonts and colors for the StatusBar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a089ecd40c8332897bcf530c1f1c0c