### PR TITLE
feat(ui): add help menu with dialogs

### DIFF
--- a/blog-writer/frontend/package-lock.json
+++ b/blog-writer/frontend/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.7.0",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1319,6 +1320,20 @@
         "@types/react-dom": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/blog-writer/frontend/package.json
+++ b/blog-writer/frontend/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/blog-writer/frontend/src/components/About.tsx
+++ b/blog-writer/frontend/src/components/About.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+
+/**
+ * About displays licensing and author information for Blog Writer.
+ */
+interface AboutProps {
+  /** Callback to close the About dialog. */
+  onClose: () => void;
+}
+
+export default function About({ onClose }: AboutProps): JSX.Element {
+  return (
+    <div style={containerStyle}>
+      <h1>Blog Writer</h1>
+      <p>This application is a static-content blog post authoring tool built by Sam Caldwell using Golang, Wails, ReactJS and TypeScript.  Please enjoy this tool and your freedom of expression.</p>
+      <h2>MIT License</h2>
+      <pre style={preStyle}>
+(c) 2025 Asymmetric Effort, LLC.  &lt;scaldwell@asymmetric-effort.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+      </pre>
+      <button type="button" onClick={onClose}>Close</button>
+    </div>
+  );
+}
+
+/** containerStyle formats the about content vertically. */
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  maxHeight: '70vh',
+  overflowY: 'auto',
+  padding: '1rem',
+  width: '600px'
+};
+
+/** preStyle preserves formatting for license text. */
+const preStyle: React.CSSProperties = {
+  whiteSpace: 'pre-wrap'
+};
+

--- a/blog-writer/frontend/src/components/BugReport.tsx
+++ b/blog-writer/frontend/src/components/BugReport.tsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+import React, { useState } from 'react';
+
+/**
+ * BugReport collects information required to file a GitHub issue.
+ */
+interface BugReportProps {
+  /** Callback to close the BugReport dialog. */
+  onClose: () => void;
+}
+
+export default function BugReport({ onClose }: BugReportProps): JSX.Element {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [steps, setSteps] = useState('');
+  const [expected, setExpected] = useState('');
+  const [actual, setActual] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const body = encodeURIComponent(`**Description**\n${description}\n\n**Steps to Reproduce**\n${steps}\n\n**Expected Behavior**\n${expected}\n\n**Actual Behavior**\n${actual}`);
+    const url = `https://github.com/asymmetric-effort/blog-writer/issues/new?title=${encodeURIComponent(title)}&body=${body}`;
+    window.open(url, '_blank');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={formStyle}>
+      <label>
+        Title
+        <input value={title} onChange={e => setTitle(e.target.value)} required />
+      </label>
+      <label>
+        Description
+        <textarea value={description} onChange={e => setDescription(e.target.value)} required />
+      </label>
+      <label>
+        Steps to Reproduce
+        <textarea value={steps} onChange={e => setSteps(e.target.value)} />
+      </label>
+      <label>
+        Expected Behavior
+        <textarea value={expected} onChange={e => setExpected(e.target.value)} />
+      </label>
+      <label>
+        Actual Behavior
+        <textarea value={actual} onChange={e => setActual(e.target.value)} />
+      </label>
+      <div style={buttonRow}>
+        <button type="submit">Submit</button>
+        <button type="button" onClick={onClose}>Close</button>
+      </div>
+    </form>
+  );
+}
+
+/** Form layout uses vertical stacking with spacing between fields. */
+const formStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  padding: '1rem',
+  width: '400px'
+};
+
+/** buttonRow displays action buttons horizontally spaced. */
+const buttonRow: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between'
+};
+

--- a/blog-writer/frontend/src/components/Documentation.tsx
+++ b/blog-writer/frontend/src/components/Documentation.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+import userGuide from '../../../../docs/user-guide.md?raw';
+
+/**
+ * Documentation displays user documentation in a scrollable view.
+ */
+interface DocumentationProps {
+  /** Callback to close the documentation dialog. */
+  onClose: () => void;
+}
+
+export default function Documentation({ onClose }: DocumentationProps): JSX.Element {
+  return (
+    <div style={containerStyle}>
+      <pre style={preStyle}>{userGuide}</pre>
+      <button type="button" onClick={onClose}>Close</button>
+    </div>
+  );
+}
+
+/** containerStyle constrains height and enables vertical scrolling. */
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  maxHeight: '70vh',
+  overflowY: 'auto',
+  padding: '1rem',
+  width: '600px'
+};
+
+/** preStyle ensures whitespace is preserved for markdown text. */
+const preStyle: React.CSSProperties = {
+  whiteSpace: 'pre-wrap'
+};
+

--- a/blog-writer/frontend/src/components/MenuBar.css
+++ b/blog-writer/frontend/src/components/MenuBar.css
@@ -23,3 +23,34 @@
 .menu-button:hover {
   background-color: #e0e0e0;
 }
+
+.help-menu {
+  position: relative;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  z-index: 100;
+}
+
+.dropdown li button {
+  display: block;
+  width: 100%;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.dropdown li button:hover {
+  background-color: #e0e0e0;
+}
+

--- a/blog-writer/frontend/src/components/MenuBar.tsx
+++ b/blog-writer/frontend/src/components/MenuBar.tsx
@@ -1,10 +1,15 @@
 // Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
 /**
- * MenuBar component renders a toolbar with common editor actions.
+ * MenuBar component renders a toolbar with common editor actions and a help menu.
  * Each action is represented by a button containing a unicode icon.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import './MenuBar.css';
+import Modal from './Modal';
+import About from './About';
+import Documentation from './Documentation';
+import BugReport from './BugReport';
 
 /** Interface describing a toolbar action. */
 interface Action {
@@ -33,9 +38,16 @@ export const actions: Action[] = [
 ];
 
 /**
- * MenuBar renders a horizontal toolbar of icon buttons.
+ * MenuBar renders a horizontal toolbar of icon buttons and the help menu.
  */
 export function MenuBar(): JSX.Element {
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [dialog, setDialog] = useState<'about' | 'docs' | 'bug' | null>(null);
+
+  const openAbout = () => { setDialog('about'); setHelpOpen(false); };
+  const openDocs = () => { setDialog('docs'); setHelpOpen(false); };
+  const openBug = () => { setDialog('bug'); setHelpOpen(false); };
+
   return (
     <div className="menu-bar">
       {actions.map(action => (
@@ -49,8 +61,36 @@ export function MenuBar(): JSX.Element {
           <span>{action.icon}</span>
         </button>
       ))}
+      <div className="help-menu">
+        <button
+          type="button"
+          className="menu-button"
+          aria-haspopup="true"
+          aria-expanded={helpOpen}
+          onClick={() => setHelpOpen(o => !o)}
+        >
+          Help
+        </button>
+        {helpOpen && (
+          <ul className="dropdown" role="menu">
+            <li><button type="button" role="menuitem" onClick={openAbout}>About...</button></li>
+            <li><button type="button" role="menuitem" onClick={openDocs}>Read the docs</button></li>
+            <li><button type="button" role="menuitem" onClick={openBug}>Report a bug</button></li>
+          </ul>
+        )}
+      </div>
+      <Modal open={dialog === 'about'} title="About Blog Writer">
+        <About onClose={() => setDialog(null)} />
+      </Modal>
+      <Modal open={dialog === 'docs'} title="Blog Writer docs">
+        <Documentation onClose={() => setDialog(null)} />
+      </Modal>
+      <Modal open={dialog === 'bug'} title="Bug Reporting">
+        <BugReport onClose={() => setDialog(null)} />
+      </Modal>
     </div>
   );
 }
 
 export default MenuBar;
+

--- a/blog-writer/frontend/src/components/__tests__/About.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/About.test.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+/**
+ * About component should display application information and license text.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import About from '../About';
+
+describe('About', () => {
+  it('renders license information', () => {
+    render(<About onClose={() => undefined} />);
+    expect(screen.getByText('Blog Writer')).toBeInTheDocument();
+    expect(screen.getByText(/MIT License/)).toBeInTheDocument();
+  });
+});

--- a/blog-writer/frontend/src/components/__tests__/BugReport.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/BugReport.test.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+/**
+ * Tests for BugReport ensure all form fields render and submission opens GitHub.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import BugReport from '../BugReport';
+
+describe('BugReport', () => {
+  it('renders required form fields', () => {
+    render(<BugReport onClose={() => undefined} />);
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+    expect(screen.getByLabelText('Description')).toBeInTheDocument();
+    expect(screen.getByLabelText('Steps to Reproduce')).toBeInTheDocument();
+  });
+
+  it('opens GitHub issue page on submit', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<BugReport onClose={() => undefined} />);
+    await userEvent.type(screen.getByLabelText('Title'), 'bug');
+    await userEvent.type(screen.getByLabelText('Description'), 'desc');
+    await userEvent.click(screen.getByText('Submit'));
+    expect(openSpy).toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});

--- a/blog-writer/frontend/src/components/__tests__/Documentation.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/Documentation.test.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+/**
+ * Documentation component should display user guide text and close button.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Documentation from '../Documentation';
+
+describe('Documentation', () => {
+  it('renders user guide content', () => {
+    render(<Documentation onClose={() => undefined} />);
+    expect(screen.getByText(/User Guide/)).toBeInTheDocument();
+  });
+});

--- a/blog-writer/frontend/src/components/__tests__/MenuBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/MenuBar.test.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
 /**
- * Tests for MenuBar component ensure all expected action buttons are rendered.
+ * Tests for MenuBar component ensure all expected action buttons and help menu functionality.
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
 import MenuBar, { actions } from '../MenuBar';
 
@@ -12,5 +14,34 @@ describe('MenuBar', () => {
     actions.forEach(action => {
       expect(screen.getByLabelText(action.label)).toBeInTheDocument();
     });
+  });
+
+  it('shows help menu items when Help is clicked', async () => {
+    render(<MenuBar />);
+    await userEvent.click(screen.getByText('Help'));
+    expect(screen.getByRole('menuitem', { name: 'About...' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Read the docs' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Report a bug' })).toBeInTheDocument();
+  });
+
+  it('opens Bug Reporting dialog', async () => {
+    render(<MenuBar />);
+    await userEvent.click(screen.getByText('Help'));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Report a bug' }));
+    expect(screen.getByText('Bug Reporting')).toBeInTheDocument();
+  });
+
+  it('opens Documentation dialog', async () => {
+    render(<MenuBar />);
+    await userEvent.click(screen.getByText('Help'));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Read the docs' }));
+    expect(screen.getByText('Blog Writer docs')).toBeInTheDocument();
+  });
+
+  it('opens About dialog', async () => {
+    render(<MenuBar />);
+    await userEvent.click(screen.getByText('Help'));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'About...' }));
+    expect(screen.getByText('About Blog Writer')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add Help dropdown with About, docs, and bug report options
- implement About, Documentation, and BugReport dialog components
- expand tests for help menu and new components

## Testing
- `cd blog-writer/frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a090fc2c2c83328b58ffd82b870365