### PR TITLE
Handle missing recent repo list

### DIFF
--- a/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
@@ -62,6 +62,7 @@ describe('FileTree', () => {
     const list = container.querySelector('.file-tree') as HTMLElement;
     const style = getComputedStyle(list);
     expect(style.marginTop).toBe('0px');
+  });
 
   it('uses the system background and a right border', () => {
     const cssPath = join(dirname(fileURLToPath(import.meta.url)), '../FileTree.css');
@@ -71,6 +72,5 @@ describe('FileTree', () => {
     const { container } = render(<FileTree repo="" onSelect={() => {}} />);
     const list = container.querySelector('.file-tree') as HTMLElement;
     expect(list).toBeInTheDocument();
-
   });
 });

--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -27,7 +27,7 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
   const [remote, setRemote] = useState('');
 
   useEffect(() => {
-    Recent().then(setRecent);
+    Recent().then((r) => setRecent(r ?? []));
   }, []);
 
   const handleExisting = async (p: string) => {
@@ -50,7 +50,8 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
     if (parentDir && repoName) {
       const full = `${parentDir}/${repoName}`;
       await Create(remote, full);
-      setRecent(await Recent());
+      const latest = await Recent();
+      setRecent(latest ?? []);
       onOpen(full);
     }
   };
@@ -77,7 +78,7 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
     cursor: 'pointer',
     margin: 0,
   };
-  const rows: RecentRepo[] = [...recent];
+  const rows: RecentRepo[] = [...(recent ?? [])];
   while (rows.length < 5) rows.push({ path: '', lastOpened: '' } as RecentRepo);
   const gridRows = rows.map(r => [
     r.path,

--- a/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
+++ b/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
@@ -100,6 +100,13 @@ describe('RepoWizard', () => {
       expect(cells[1].textContent).toBe('\u00A0');
     }
   });
+  it('handles undefined recent repositories', async () => {
+    const svc = (window as any).go.services.RepoService;
+    svc.Recent.mockResolvedValue(undefined);
+    render(<RepoWizard onOpen={vi.fn()} />);
+    const rows = await screen.findAllByTestId('recent-row');
+    expect(rows).toHaveLength(5);
+  });
   it('uses Grid component with styled borders for recent repositories', async () => {
     render(<RepoWizard onOpen={vi.fn()} />);
     const grid = await screen.findByTestId('recent-grid');


### PR DESCRIPTION
## Summary
- Guard RepoWizard against `Recent()` returning null to avoid spread errors
- Add regression test for undefined recent repos
- Fix FileTree test structure so test suite runs

## Testing
- `cd blog-writer/frontend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_b_68a092371d5c8332b8d5c6be1d06b53c