### PR TITLE
Add Help options to OS menu bar

### DIFF
--- a/blog-writer/app.go
+++ b/blog-writer/app.go
@@ -39,3 +39,13 @@ func (a *App) ShowAbout(data *menu.CallbackData) {
 		Message: about.Info(),
 	})
 }
+
+// ShowDocs opens the project documentation in the user's default browser.
+func (a *App) ShowDocs(data *menu.CallbackData) {
+	runtime.BrowserOpenURL(a.ctx, "https://github.com/asymmetric-effort/blog-writer/blob/main/docs/user-guide.md")
+}
+
+// ReportBug opens the bug report page in the user's default browser.
+func (a *App) ReportBug(data *menu.CallbackData) {
+	runtime.BrowserOpenURL(a.ctx, "https://github.com/asymmetric-effort/blog-writer/issues/new/choose")
+}

--- a/blog-writer/main.go
+++ b/blog-writer/main.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 
 	wails "github.com/wailsapp/wails/v2"
-	"github.com/wailsapp/wails/v2/pkg/menu"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 
@@ -26,9 +25,7 @@ func main() {
 	treeSvc := services.NewTreeService()
 
 	// Create application menu.
-	appMenu := menu.NewMenu()
-	helpMenu := appMenu.AddSubmenu("Help")
-	helpMenu.AddText("About", nil, app.ShowAbout)
+	appMenu := newAppMenu(app)
 
 	// Create application with options.
 	err = wails.Run(&options.App{

--- a/blog-writer/menu.go
+++ b/blog-writer/menu.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+package main
+
+import "github.com/wailsapp/wails/v2/pkg/menu"
+
+// newAppMenu constructs the application menu including a Help submenu with
+// entries for About, documentation, and bug reporting.
+func newAppMenu(app *App) *menu.Menu {
+	appMenu := menu.NewMenu()
+	helpMenu := appMenu.AddSubmenu("Help")
+	helpMenu.AddText("About", nil, app.ShowAbout)
+	helpMenu.AddText("Read the docs", nil, app.ShowDocs)
+	helpMenu.AddText("Report a bug", nil, app.ReportBug)
+	return appMenu
+}

--- a/blog-writer/menu_test.go
+++ b/blog-writer/menu_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/wailsapp/wails/v2/pkg/menu"
+)
+
+// TestNewAppMenuHelpItems ensures the help menu contains all expected entries.
+func TestNewAppMenuHelpItems(t *testing.T) {
+	app := NewApp()
+	m := newAppMenu(app)
+
+	// Locate the Help submenu
+	var help *menu.Menu
+	for _, item := range m.Items {
+		if item.Label == "Help" && item.Type == menu.SubmenuType {
+			help = item.SubMenu
+			break
+		}
+	}
+	if help == nil {
+		t.Fatal("help submenu not found")
+	}
+
+	if len(help.Items) != 3 {
+		t.Fatalf("expected 3 help items, got %d", len(help.Items))
+	}
+
+	expected := []string{"About", "Read the docs", "Report a bug"}
+	for i, label := range expected {
+		if help.Items[i].Label != label {
+			t.Errorf("expected item %d label %q, got %q", i, label, help.Items[i].Label)
+		}
+		if help.Items[i].Click == nil {
+			t.Errorf("item %q missing click handler", label)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expose About, docs and bug report options in the OS Help menu
- add menu unit test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a093864d048332b2f743e9060b7288