### PR TITLE
feat: ensure spacing between create tab inputs

### DIFF
--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -78,6 +78,8 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
     cursor: 'pointer',
     margin: 0,
   };
+  const inputSpacing = 10;
+  const sshInputStyle: React.CSSProperties = { marginTop: `${inputSpacing}px` };
   const rows: RecentRepo[] = [...(recent ?? [])];
   while (rows.length < 5) rows.push({ path: '', lastOpened: '' } as RecentRepo);
   const gridRows = rows.map(r => [
@@ -145,6 +147,7 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
             placeholder="SSH URL (optional)"
             value={remote}
             onChange={(e) => setRemote(e.target.value)}
+            style={sshInputStyle}
           />
           <button onClick={handleCreate}>Create</button>
           <p className="hint" style={{ marginTop: 'auto' }}>

--- a/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
+++ b/blog-writer/frontend/src/pages/__tests__/RepoWizard.test.tsx
@@ -48,6 +48,13 @@ describe('RepoWizard', () => {
     expect(button.nextElementSibling).toBe(hint);
   });
 
+  it('adds 10px margin between repository and SSH inputs', () => {
+    render(<RepoWizard onOpen={vi.fn()} />);
+    fireEvent.click(screen.getByText('Create'));
+    const boxes = screen.getAllByRole('textbox');
+    expect(boxes[1]).toHaveStyle({ marginTop: '10px' });
+  });
+
   it('highlights tab on hover', () => {
     render(<RepoWizard onOpen={vi.fn()} />);
     const openTab = screen.getByText('Open');


### PR DESCRIPTION
## Summary
- maintain 10px gap between repository name and SSH URL fields
- add regression test for create tab input spacing

## Testing
- `npm test -- --run`
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68a095e87c6083329bade1e45676fc71