### PR TITLE
feat: replace help menu text with icon

### DIFF
--- a/blog-writer/frontend/src/components/MenuBar.tsx
+++ b/blog-writer/frontend/src/components/MenuBar.tsx
@@ -10,6 +10,7 @@ import Modal from './Modal';
 import About from './About';
 import Documentation from './Documentation';
 import BugReport from './BugReport';
+import HelpIcon from './icons/HelpIcon';
 
 /** Interface describing a toolbar action. */
 interface Action {
@@ -65,11 +66,12 @@ export function MenuBar(): JSX.Element {
         <button
           type="button"
           className="menu-button"
+          aria-label="Help"
           aria-haspopup="true"
           aria-expanded={helpOpen}
           onClick={() => setHelpOpen(o => !o)}
         >
-          Help
+          <HelpIcon />
         </button>
         {helpOpen && (
           <ul className="dropdown" role="menu">

--- a/blog-writer/frontend/src/components/__tests__/MenuBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/MenuBar.test.tsx
@@ -16,9 +16,9 @@ describe('MenuBar', () => {
     });
   });
 
-  it('shows help menu items when Help is clicked', async () => {
+  it('shows help menu items when Help icon is clicked', async () => {
     render(<MenuBar />);
-    await userEvent.click(screen.getByText('Help'));
+    await userEvent.click(screen.getByRole('button', { name: 'Help' }));
     expect(screen.getByRole('menuitem', { name: 'About...' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Read the docs' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Report a bug' })).toBeInTheDocument();
@@ -26,22 +26,29 @@ describe('MenuBar', () => {
 
   it('opens Bug Reporting dialog', async () => {
     render(<MenuBar />);
-    await userEvent.click(screen.getByText('Help'));
+    await userEvent.click(screen.getByRole('button', { name: 'Help' }));
     await userEvent.click(screen.getByRole('menuitem', { name: 'Report a bug' }));
     expect(screen.getByText('Bug Reporting')).toBeInTheDocument();
   });
 
   it('opens Documentation dialog', async () => {
     render(<MenuBar />);
-    await userEvent.click(screen.getByText('Help'));
+    await userEvent.click(screen.getByRole('button', { name: 'Help' }));
     await userEvent.click(screen.getByRole('menuitem', { name: 'Read the docs' }));
     expect(screen.getByText('Blog Writer docs')).toBeInTheDocument();
   });
 
   it('opens About dialog', async () => {
     render(<MenuBar />);
-    await userEvent.click(screen.getByText('Help'));
+    await userEvent.click(screen.getByRole('button', { name: 'Help' }));
     await userEvent.click(screen.getByRole('menuitem', { name: 'About...' }));
     expect(screen.getByText('About Blog Writer')).toBeInTheDocument();
+  });
+
+  it('renders the Help button as an icon', () => {
+    render(<MenuBar />);
+    const helpButton = screen.getByRole('button', { name: 'Help' });
+    expect(helpButton).not.toHaveTextContent('Help');
+    expect(screen.getByTestId('help-icon')).toBeInTheDocument();
   });
 });

--- a/blog-writer/frontend/src/components/icons/HelpIcon.css
+++ b/blog-writer/frontend/src/components/icons/HelpIcon.css
@@ -1,0 +1,13 @@
+/* Copyright (c) 2025 Sam Caldwell */
+.help-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: #1e90ff;
+  color: #fff;
+  font-weight: bold;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+}

--- a/blog-writer/frontend/src/components/icons/HelpIcon.tsx
+++ b/blog-writer/frontend/src/components/icons/HelpIcon.tsx
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+/**
+ * HelpIcon renders a blue circular icon with a white embossed question mark.
+ */
+import React from 'react';
+import './HelpIcon.css';
+
+/**
+ * HelpIcon component used for the help menu button.
+ *
+ * @returns JSX.Element representing a help icon.
+ */
+export function HelpIcon(): JSX.Element {
+  return <span className="help-icon" data-testid="help-icon" aria-hidden="true">?</span>;
+}
+
+export default HelpIcon;


### PR DESCRIPTION
## Summary
- replace Help text button with blue question-mark icon
- add HelpIcon component and styles
- update tests for icon-based Help menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a0965cd50c8332963ccdc329953523