### PR TITLE
fix: improve repo wizard types

### DIFF
--- a/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/FileTree.test.tsx
@@ -3,9 +3,9 @@
 /// <reference types="vitest" />
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import '@testing-library/jest-dom/vitest';
 import FileTree from '../FileTree';
 

--- a/blog-writer/frontend/src/pages/RepoWizard.tsx
+++ b/blog-writer/frontend/src/pages/RepoWizard.tsx
@@ -27,9 +27,14 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
   const [remote, setRemote] = useState('');
 
   useEffect(() => {
-    Recent().then((r) => setRecent(r ?? []));
+    Recent().then((r) =>
+      setRecent((r ?? []).map((p) => ({ path: p, lastOpened: '' })))
+    );
   }, []);
 
+  /**
+   * Attempt to open an existing repository, initializing it if needed.
+   */
   const handleExisting = async (p: string) => {
     try {
       await Open(p);
@@ -46,16 +51,18 @@ export default function RepoWizard({ onOpen }: RepoWizardProps) {
     }
   };
 
+  /** Create a new repository at the chosen path and open it. */
   const handleCreate = async () => {
     if (parentDir && repoName) {
       const full = `${parentDir}/${repoName}`;
       await Create(remote, full);
       const latest = await Recent();
-      setRecent(latest ?? []);
+      setRecent((latest ?? []).map((p) => ({ path: p, lastOpened: '' })));
       onOpen(full);
     }
   };
 
+  /** Open a repository from the recent list. */
   const openRecent = async (p: string) => {
     try {
       await Open(p);


### PR DESCRIPTION
## Summary
- use Node built-in module names in FileTree tests
- map recent repository paths to typed objects in RepoWizard
- document RepoWizard helpers

## Testing
- `npx --prefix blog-writer/frontend tsc --noEmit -p blog-writer/frontend`
- `npx --prefix blog-writer/frontend vitest run` *(fails: window/document is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68a099274bc08332b7c4cbb285ac8055