### PR TITLE
Add beveled borders to menu and status bars

### DIFF
--- a/blog-writer/frontend/src/components/MenuBar.css
+++ b/blog-writer/frontend/src/components/MenuBar.css
@@ -5,7 +5,7 @@
   gap: 0.5rem;
   padding: 0.25rem;
   background-color: #f0f0f0;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px outset;
 }
 
 .menu-button {

--- a/blog-writer/frontend/src/components/MenuBar.tsx
+++ b/blog-writer/frontend/src/components/MenuBar.tsx
@@ -45,12 +45,16 @@ export function MenuBar(): JSX.Element {
   const [helpOpen, setHelpOpen] = useState(false);
   const [dialog, setDialog] = useState<'about' | 'docs' | 'bug' | null>(null);
 
+  const style: React.CSSProperties = {
+    borderBottom: '1px outset',
+  };
+
   const openAbout = () => { setDialog('about'); setHelpOpen(false); };
   const openDocs = () => { setDialog('docs'); setHelpOpen(false); };
   const openBug = () => { setDialog('bug'); setHelpOpen(false); };
 
   return (
-    <div className="menu-bar">
+    <div className="menu-bar" style={style}>
       {actions.map(action => (
         <button
           key={action.label}

--- a/blog-writer/frontend/src/components/StatusBar.css
+++ b/blog-writer/frontend/src/components/StatusBar.css
@@ -9,5 +9,6 @@
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     Roboto, Helvetica, Arial, sans-serif;
   color-scheme: light dark;
+  border-top: 1px outset;
   width: 100%;
 }

--- a/blog-writer/frontend/src/components/StatusBar.tsx
+++ b/blog-writer/frontend/src/components/StatusBar.tsx
@@ -24,6 +24,7 @@ export default function StatusBar({ repo, file, wizardOpen }: StatusBarProps): J
     background: 'Canvas',
     color: 'CanvasText',
     colorScheme: 'light dark',
+    borderTop: '1px outset',
     width: '100%',
   };
   return (

--- a/blog-writer/frontend/src/components/__tests__/MenuBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/MenuBar.test.tsx
@@ -51,4 +51,11 @@ describe('MenuBar', () => {
     expect(helpButton).not.toHaveTextContent('Help');
     expect(screen.getByTestId('help-icon')).toBeInTheDocument();
   });
+
+  it('renders an outset bottom border', () => {
+    const { container } = render(<MenuBar />);
+    const bar = container.querySelector('.menu-bar') as HTMLElement;
+    const styles = getComputedStyle(bar);
+    expect(styles.borderBottomStyle).toBe('outset');
+  });
 });

--- a/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/StatusBar.test.tsx
@@ -28,4 +28,11 @@ describe('StatusBar', () => {
     expect(styles.fontFamily.toLowerCase()).toContain('system-ui');
     expect(styles.backgroundColor).not.toBe('');
   });
+
+  it('renders an outset top border', () => {
+    const { container } = render(<StatusBar repo="" file="" wizardOpen={false} />);
+    const bar = container.querySelector('.status-bar') as HTMLElement;
+    const styles = getComputedStyle(bar);
+    expect(styles.borderTopStyle).toBe('outset');
+  });
 });


### PR DESCRIPTION
## Summary
- add top bevel border to StatusBar
- add bottom bevel border to MenuBar
- test borders for menu and status bars

## Testing
- `npm test -- --run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a08ba275f48332973fa6b61f1d88b0