### PR TITLE
feat: add custom about dialog icon

### DIFF
--- a/blog-writer/app.go
+++ b/blog-writer/app.go
@@ -37,6 +37,7 @@ func (a *App) ShowAbout(data *menu.CallbackData) {
 	runtime.MessageDialog(a.ctx, runtime.MessageDialogOptions{
 		Title:   "About",
 		Message: about.Info(),
+		Icon:    about.Icon(),
 	})
 }
 

--- a/blog-writer/internal/about/about_test.go
+++ b/blog-writer/internal/about/about_test.go
@@ -1,7 +1,12 @@
 // Copyright (c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
 package about
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // TestInfo verifies that Info returns the correct about message.
 func TestInfo(t *testing.T) {
@@ -35,5 +40,17 @@ P.S. Fuck Trump and the uneducated, uninformed dimwits who elected him!
 
 	if Info() != expected {
 		t.Errorf("expected about info to match\n%s\n got\n%s", expected, Info())
+	}
+}
+
+// TestIcon verifies that Icon returns the expected image data.
+func TestIcon(t *testing.T) {
+	expected, err := os.ReadFile(filepath.Join("..", "..", "..", "docs", "blog-writer.png"))
+	if err != nil {
+		t.Fatalf("unable to read icon file: %v", err)
+	}
+
+	if !bytes.Equal(Icon(), expected) {
+		t.Errorf("icon bytes do not match test fixture")
 	}
 }

--- a/blog-writer/internal/about/icon.go
+++ b/blog-writer/internal/about/icon.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 Asymmetric Effort, LLC. <scaldwell@asymmetric-effort.com>
+package about
+
+import _ "embed"
+
+// iconBytes holds the PNG data for the About dialog icon.
+// The source image lives in ../../docs/blog-writer.png; copy it here with:
+//
+//     cp ../../docs/blog-writer.png blog-writer.png
+//
+//go:embed blog-writer.png
+var iconBytes []byte
+
+// Icon returns the PNG image used for the About dialog.
+func Icon() []byte {
+	return iconBytes
+}


### PR DESCRIPTION
## Summary
- embed blog-writer icon for About dialog
- display embedded icon in About dialog
- test About icon bytes against reference image
- document how to copy the source icon without storing the binary asset

## Testing
- `make test`
- `npm test --prefix blog-writer/frontend` *(fails: Unable to find an element with the text: r1)*

------
https://chatgpt.com/codex/tasks/task_b_68a09d16b6c08332910a9e545553890c