### PR TITLE
fix: resolve directory selection

### DIFF
--- a/blog-writer/frontend/src/components/DirectoryPicker.tsx
+++ b/blog-writer/frontend/src/components/DirectoryPicker.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import React, { useCallback, useRef } from 'react';
+import { CanResolveFilePaths, ResolveFilePaths } from '../../wailsjs/runtime/runtime';
 
 /**
  * DirectoryPicker renders a directory selector used by RepoWizard forms.
@@ -46,11 +47,20 @@ export default function DirectoryPicker({ onChange, ...rest }: DirectoryPickerPr
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (files && files.length > 0) {
+      try {
+        if (CanResolveFilePaths()) {
+          ResolveFilePaths(Array.from(files));
+        }
+      } catch {
+        // runtime not available; continue without resolving
+      }
       const file = files[0] as File & { path?: string };
       const fullPath = file.path || '';
-      const separator = fullPath.includes('/') ? '/' : '\\';
-      const dir = fullPath.substring(0, fullPath.lastIndexOf(separator));
-      onChange(dir);
+      if (fullPath) {
+        const separator = fullPath.includes('/') ? '/' : '\\';
+        const dir = fullPath.substring(0, fullPath.lastIndexOf(separator));
+        onChange(dir);
+      }
     }
   }, [onChange]);
 

--- a/blog-writer/frontend/src/components/__tests__/DirectoryPicker.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/DirectoryPicker.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 blog-writer authors
 // SPDX-License-Identifier: MIT
 /// <reference types="vitest" />
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import DirectoryPicker from '../DirectoryPicker';
@@ -10,6 +10,9 @@ import DirectoryPicker from '../DirectoryPicker';
  * Basic interaction test ensuring DirectoryPicker returns a directory path.
  */
 describe('DirectoryPicker', () => {
+  afterEach(() => {
+    delete (window as any).runtime;
+  });
   it('invokes onChange with selected path', () => {
     const onChange = vi.fn();
     const { container } = render(<DirectoryPicker onChange={onChange} />);
@@ -28,5 +31,22 @@ describe('DirectoryPicker', () => {
     Object.defineProperty(file, 'path', { value: 'C:\\Users\\Alice\\repo\\a.txt' });
     fireEvent.change(input, { target: { files: [file] } });
     expect(onChange).toHaveBeenCalledWith('C:\\Users\\Alice\\repo');
+  });
+
+  it('resolves file path via Wails runtime when missing', () => {
+    const onChange = vi.fn();
+    const resolve = vi.fn((files: File[]) => {
+      Object.defineProperty(files[0], 'path', { value: '/tmp/test/a.txt', configurable: true });
+    });
+    (window as any).runtime = {
+      CanResolveFilePaths: () => true,
+      ResolveFilePaths: resolve,
+    };
+    const { container } = render(<DirectoryPicker onChange={onChange} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    const file = new File(['content'], 'a.txt');
+    fireEvent.change(input, { target: { files: [file] } });
+    expect(resolve).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith('/tmp/test');
   });
 });


### PR DESCRIPTION
## Summary
- use Wails runtime to resolve directory paths before deriving parent folder
- test runtime path resolution in DirectoryPicker

## Testing
- `npm test -- --run`
- `make test` *(fails: internal/about/icon.go:11:12: pattern blog-writer.png: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0a8351b6c8332b4a46b5ca5a05c54