### PR TITLE
fix: return directory path from picker

### DIFF
--- a/blog-writer/frontend/src/components/DirectoryPicker.tsx
+++ b/blog-writer/frontend/src/components/DirectoryPicker.tsx
@@ -22,7 +22,9 @@ export default function DirectoryPicker({ onChange, ...rest }: DirectoryPickerPr
 
   /**
    * Triggers directory selection using File System Access API or the fallback
-   * file input when unsupported.
+   * file input when unsupported. Some environments (e.g., Wails) return a
+   * string path instead of a directory handle; this function normalizes the
+   * result and falls back to the hidden input if a path cannot be determined.
    */
   const handleClick = useCallback(async () => {
     try {
@@ -30,9 +32,15 @@ export default function DirectoryPicker({ onChange, ...rest }: DirectoryPickerPr
       if (window.showDirectoryPicker) {
         // @ts-ignore
         const handle = await window.showDirectoryPicker();
-        const path = (handle as any).path || (handle as any).name || '';
-        onChange(path);
-        return;
+        if (typeof handle === 'string') {
+          onChange(handle);
+          return;
+        }
+        const path = (handle as any).path || (handle as any).name;
+        if (path) {
+          onChange(path);
+          return;
+        }
       }
     } catch {
       // Ignore and fall back to the hidden input below.

--- a/blog-writer/frontend/src/components/__tests__/DirectoryPicker.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/DirectoryPicker.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 /// <reference types="vitest" />
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import DirectoryPicker from '../DirectoryPicker';
 
@@ -12,6 +12,14 @@ import DirectoryPicker from '../DirectoryPicker';
 describe('DirectoryPicker', () => {
   afterEach(() => {
     delete (window as any).runtime;
+    delete (window as any).showDirectoryPicker;
+  });
+  it('returns path when showDirectoryPicker provides one', async () => {
+    const onChange = vi.fn();
+    (window as any).showDirectoryPicker = vi.fn().mockResolvedValue('/tmp/repo');
+    const { getByRole } = render(<DirectoryPicker onChange={onChange} />);
+    fireEvent.click(getByRole('button'));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('/tmp/repo'));
   });
   it('invokes onChange with selected path', () => {
     const onChange = vi.fn();


### PR DESCRIPTION
## Summary
- handle path strings returned by `showDirectoryPicker`
- test `DirectoryPicker` integration with `showDirectoryPicker`

## Testing
- `npx --prefix blog-writer/frontend tsc --noEmit`
- `npm --prefix blog-writer/frontend test -- --run`
- `cd blog-writer && go test ./...` *(fails: pattern blog-writer.png: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0ad681c18833287a47ca92d0647bd