### PR TITLE
feat: add tree directory picker

### DIFF
--- a/blog-writer/frontend/src/components/DirectoryTree.tsx
+++ b/blog-writer/frontend/src/components/DirectoryTree.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 blog-writer authors
+// SPDX-License-Identifier: MIT
+
+import React from 'react';
+
+/** Directory node used by DirectoryTree. */
+export interface DirNode {
+  /** Full path to the directory. */
+  path: string;
+  /** Base name of the directory. */
+  name: string;
+  /** Child directories. */
+  children: DirNode[];
+}
+
+/** Props for DirectoryTree component. */
+interface DirectoryTreeProps {
+  /** Nodes to render. */
+  nodes: DirNode[];
+  /** Currently selected path. */
+  selected: string;
+  /** Callback when a directory is chosen. */
+  onSelect: (path: string) => void;
+}
+
+/**
+ * DirectoryTree recursively renders directories as nested lists.
+ */
+export default function DirectoryTree({ nodes, selected, onSelect }: DirectoryTreeProps): JSX.Element {
+  return (
+    <ul>
+      {nodes.map((n) => (
+        <li key={n.path}>
+          <button
+            onClick={() => onSelect(n.path)}
+            data-testid="dir-item"
+            style={{ fontWeight: selected === n.path ? 'bold' : 'normal' }}
+          >
+            {n.name}
+          </button>
+          {n.children.length > 0 && (
+            <DirectoryTree nodes={n.children} selected={selected} onSelect={onSelect} />
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+


### PR DESCRIPTION
## Summary
- render directory choices as an expandable tree with vertical scrolling limited to 500px
- refactor picker logic into modular DirectoryTree component
- test tree rendering, selection, and height constraints

## Testing
- `npm test`
- `go test ./...` *(fails: pattern blog-writer.png: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0b3aba12483329129fc9378356d1f