### PR TITLE
feat: close directory picker on escape

### DIFF
--- a/blog-writer/frontend/src/components/DirectoryPicker.tsx
+++ b/blog-writer/frontend/src/components/DirectoryPicker.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 blog-writer authors
 // SPDX-License-Identifier: MIT
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Create, List } from '../../wailsjs/go/services/DirectoryService';
 
 /** Props for DirectoryPicker component. */
@@ -15,6 +15,13 @@ function DirectoryModal({ onSelect, onClose }: { onSelect: (p: string) => void; 
   const [path, setPath] = useState('');
   const [dirs, setDirs] = useState<string[]>([]);
   const [newName, setNewName] = useState('');
+
+  /** Handles closing the modal when the escape key is pressed. */
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  }, [onClose]);
 
   const parentDir = (p: string): string => {
     const parts = p.split(/[/\\]/);
@@ -41,6 +48,13 @@ function DirectoryModal({ onSelect, onClose }: { onSelect: (p: string) => void; 
     load('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   const navigate = (d: string) => {
     load(d);

--- a/blog-writer/frontend/src/components/__tests__/DirectoryPicker.test.tsx
+++ b/blog-writer/frontend/src/components/__tests__/DirectoryPicker.test.tsx
@@ -47,5 +47,15 @@ describe('DirectoryPicker', () => {
     fireEvent.click(getByTestId('create-btn'));
     await waitFor(() => expect(DirSvc.Create).toHaveBeenCalledWith('/tmp', 'foo'));
   });
+
+  it('closes modal on escape key', async () => {
+    (DirSvc.List as any).mockResolvedValue([]);
+    const onChange = vi.fn();
+    const { getByRole, queryByRole } = render(<DirectoryPicker onChange={onChange} />);
+    fireEvent.click(getByRole('button', { name: /browse/i }));
+    await waitFor(() => expect(DirSvc.List).toHaveBeenCalled());
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    await waitFor(() => expect(queryByRole('dialog')).not.toBeInTheDocument());
+  });
 });
 


### PR DESCRIPTION
## Summary
- close DirectoryPicker modal when Escape key is pressed
- add regression test for Escape cancellation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a0b867b768833296a6335e2ddde88e